### PR TITLE
Eventモデル追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ gem 'omniauth-facebook'
 gem 'omniauth-rails_csrf_protection'
 
 gem 'bootstrap-sass'
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.1.7)
       actionpack (= 6.1.7)
       activesupport (= 6.1.7)
@@ -272,6 +275,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.6)
+  rails-i18n
   sass-rails (>= 6)
   selenium-webdriver (>= 4.0.0.rc1)
   spring

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action :authenticate_user!
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,2 @@
+class EventsController < ApplicationController
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,6 +7,7 @@ class EventsController < ApplicationController
     @event = current_user.created_events.build(event_params)
 
     if @event.save
+      # redirect_to @event, notice: "作成しました"
       redirect_to new_event_path, notice: "作成しました"
     else 
       render 'new'

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,6 @@
 class EventsController < ApplicationController
+skip_before_action :authenticate_user!, only: :show
+
   def new
     @event = current_user.created_events.build
   end
@@ -7,11 +9,14 @@ class EventsController < ApplicationController
     @event = current_user.created_events.build(event_params)
 
     if @event.save
-      # redirect_to @event, notice: "作成しました"
-      redirect_to new_event_path, notice: "作成しました"
+      redirect_to @event, notice: "作成しました"
     else 
       render 'new'
     end
+  end
+
+  def show
+    @event = Event.find(params[:id])
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,23 @@
 class EventsController < ApplicationController
+  def new
+    @event = current_user.created_events.build
+  end
+
+  def create
+    @event = current_user.created_events.build(event_params)
+
+    if @event.save
+      redirect_to @event, notice: "作成しました"
+    else 
+      render 'new'
+    end
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(
+      :name, :place, :title, :discription, :price, :required_time, :is_published, :capacitiy
+    )
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,7 +7,7 @@ class EventsController < ApplicationController
     @event = current_user.created_events.build(event_params)
 
     if @event.save
-      redirect_to @event, notice: "作成しました"
+      redirect_to new_event_path, notice: "作成しました"
     else 
       render 'new'
     end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  skip_before_action :authenticate_user!
+  
   def index
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,5 +2,6 @@ class HomeController < ApplicationController
   skip_before_action :authenticate_user!
   
   def index
+    @events = Event.all
   end
 end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,5 +6,5 @@ class Event < ApplicationRecord
   validates :price, length: { maximum: 7 }, presence: true
   validates :required_time, length: { maximum: 3 }, presence: true
   validates :capacitiy, length: { maximum: 3 }, presence: true
-  validates :is_published, presence: true
+  validates :is_published, inclusion: {in: [true, false]}
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,10 @@
 class Event < ApplicationRecord
+  validates :name, length: { maximum: 50 }, presence: true
+  validates :place, length: { maximum: 100 }, presence: true
+  validates :title, length: { maximum: 100 }, presence: true
+  validates :discription, length: { maximum: 2000 }, presence: true
+  validates :price, length: { maximum: 7 }, presence: true
+  validates :required_time, length: { maximum: 3 }, presence: true
+  validates :capacitiy, length: { maximum: 3 }, presence: true
+  validates :is_published, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  belongs_to :owner, class_name: "User"
+
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :title, length: { maximum: 100 }, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :created_events, class_name: "Event", foreign_key: "owner_id"
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook]
 

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,38 @@
+
+<h1 class="mt-2">ココロミを登録</h1>
+<%= form_with(model: @event, local: true) do |f| %> 
+  <%= render 'shared/error_messages' %>
+  <div class="form-group">
+    <%= f.label :name %> 
+    <%= f.text_field :name, class: "form-control" %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :title %> 
+    <%= f.text_field :title, class: "form-control" %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :discription %> 
+    <%= f.text_area :discription, class: "form-control", row: 10 %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :place %> 
+    <%= f.text_field :place, class: "form-control" %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :price %> 
+    <%= f.text_field :price, class: "form-control" %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :required_time %> 
+    <%= f.text_field :required_time, class: "form-control" %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :capacitiy %> 
+    <%= f.text_field :capacitiy, class: "form-control" %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :is_published %> 
+    <%= f.select :is_published, ['published', 'hidden'], {}, { class: "form-control" } %>
+  </div>
+  <%= f.submit class: "btn btn-primary" %> 
+<% end %> 

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -32,7 +32,7 @@
   </div>
   <div class="form-group">
     <%= f.label :is_published %> 
-    <%= f.select :is_published, ['published', 'hidden'], {}, { class: "form-control" } %>
+    <%= f.select :is_published, [['公開', true], ['非公開', false]], {}, { class: "form-control" } %>
   </div>
   <%= f.submit class: "btn btn-primary" %> 
 <% end %> 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,46 @@
+<h1 class="mt-3 mb-3"><%= @event.name %> </h1>
+<div class="card mb-2">
+  <h5 class="card-header">タイトル</h5>
+  <div class="card-body">
+    <p class="card-text"><%= @event.title %> </p>
+  </div>
+</div>
+<div class="card mb-2">
+  <h5 class="card-header">イベント内容</h5>
+  <div class="card-body">
+    <p class="card-text"><%= @event.discription %> </p>
+  </div>
+</div>
+<div class="card mb-2">
+  <h5 class="card-header">場所</h5>
+  <div class="card-body">
+    <p class="card-text"><%= @event.place %> </p>
+  </div>
+</div>
+<div class="card mb-2">
+  <h5 class="card-header">価格</h5>
+  <div class="card-body">
+    <p class="card-text"><%= @event.price %> </p>
+  </div>
+</div>
+<div class="card mb-2">
+  <h5 class="card-header">所要時間</h5>
+  <div class="card-body">
+    <p class="card-text"><%= @event.required_time %> </p>
+  </div>
+</div>
+<div class="card mb-2">
+  <h5 class="card-header">定員</h5>
+  <div class="card-body">
+    <p class="card-text"><%= @event.required_time %> </p>
+  </div>
+</div>
+<div class="card mb-2">
+  <h5 class="card-header">作家さん</h5>
+  <div class="card-body">
+    <%= link_to(@event.owner.name, class: "card-link") do %> 
+      <%= image_tag @event.owner.image, width: 50, height: 50 %> 
+      <%= "@#{@event.owner.name}" %>
+    <% end %> 
+  </div>
+</div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,10 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<h1>ココロミ一覧</h1>
+
+<ul class="list-group">
+  <% @events.each do |event| %> 
+    <%= link_to(event, class: 'list-group-item list-group-item-action') do %> 
+      <h5 class="list-group-item-heading"><%= event.name %> </h5>
+      <p class="mb-1"><%= event.title %> </p>
+    <% end %> 
+  <% end %> 
+</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
         <%= link_to "wakuraku", root_path, class: "navbar-brand" %>
         <ul class="nav navbar-nav navbar-right">
           <% if user_signed_in? %> 
+            <li><%= link_to "ココロミをつくる", "" %></li>
             <li><%= link_to 'ログアウト', users_sign_out_path %></li>
           <% else %> 
             <li><%= link_to "ログイン", new_user_session_path %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
         <%= link_to "wakuraku", root_path, class: "navbar-brand" %>
         <ul class="nav navbar-nav navbar-right">
           <% if user_signed_in? %> 
-            <li><%= link_to "ココロミをつくる", "" %></li>
+            <li><%= link_to "ココロミをつくる", new_event_path %></li>
             <li><%= link_to 'ログアウト', users_sign_out_path %></li>
           <% else %> 
             <li><%= link_to "ログイン", new_user_session_path %></li>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
         <ul class="nav navbar-nav navbar-right">
           <% if user_signed_in? %> 
             <li><%= link_to "ココロミをつくる", new_event_path %></li>
-            <li><%= link_to 'ログアウト', users_sign_out_path %></li>
+            <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
           <% else %> 
             <li><%= link_to "ログイン", new_user_session_path %></li>
           <% end %> 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @event.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      The form contains <%= pluralize(@event.errors.count, "error") %>.
+    </div>
+    <ul>
+    <% @event.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Wakuraku
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
     config.time_zone = "Tokyo"
+    config.i18n.default_locale = :ja
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Wakuraku
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
+    config.time_zone = "Tokyo"
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,22 @@
+ja:
+  activerecord:
+    models:
+      event: イベント
+    attributes:
+      event:
+        name: 名前
+        place: 場所
+        title: タイトル
+        discription: 詳細
+        price: 価格
+        required_time: 所要時間
+        is_published: 公開設定
+        capacitiy: 人数制限
+  devise:
+    sessions:
+      user:
+        signed_out: ログアウトしました
+    omniauth_callbacks:
+      user:
+        success: ログインしました
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -15,6 +15,7 @@ ja:
   devise:
     sessions:
       user:
+        signed_in: ログインしました
         signed_out: ログアウトしました
     omniauth_callbacks:
       user:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,7 +11,7 @@ ja:
         price: 価格
         required_time: 所要時間
         is_published: 公開設定
-        capacitiy: 人数制限
+        capacitiy: 定員
   devise:
     sessions:
       user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :events
   root 'home#index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,4 @@ Rails.application.routes.draw do
   resources :events
   root 'home#index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
-  devise_scope :user do
-    get '/users/sign_out' => 'devise/sessions#destroy'
-  end   
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20221016100238_create_events.rb
+++ b/db/migrate/20221016100238_create_events.rb
@@ -1,0 +1,20 @@
+class CreateEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :events do |t|
+      t.bigint :owner_id
+      t.string :name, null: false
+      t.string :place, null: false
+      t.string :title, null: false
+      t.text :discription, null: false
+      t.string :thumbnail_url
+      t.integer :price, null: false
+      t.integer :required_time, null: false
+      t.boolean :is_published, null: false
+      t.integer :capacitiy, null: false
+
+      t.timestamps
+    end
+
+    add_index :events, :owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_16_074619) do
+ActiveRecord::Schema.define(version: 2022_10_16_100238) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.bigint "owner_id"
+    t.string "name", null: false
+    t.string "place", null: false
+    t.string "title", null: false
+    t.text "discription", null: false
+    t.string "thumbnail_url"
+    t.integer "price", null: false
+    t.integer "required_time", null: false
+    t.boolean "is_published", null: false
+    t.integer "capacitiy", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["owner_id"], name: "index_events_on_owner_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,27 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  owner_id: 
+  name: MyString
+  place: MyString
+  title: MyString
+  subtitle: MyString
+  discription: MyText
+  thumbnail_url: MyString
+  price: 1
+  required_time: 1
+  is_published: false
+  capacitiy: 1
+
+two:
+  owner_id: 
+  name: MyString
+  place: MyString
+  title: MyString
+  subtitle: MyString
+  discription: MyText
+  thumbnail_url: MyString
+  price: 1
+  required_time: 1
+  is_published: false
+  capacitiy: 1

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## やったこと
- Eventモデルを追加しUserと関連付け
- omniauthを使用したFacebook認証機能を追加
- i18nによる国際化対応

## やらないこと
- Eventの編集・削除機能

## できるようになること（ユーザ目線）

- Eventの一覧・詳細確認、新規作成が可能になる。

## できなくなること（ユーザ目線）

- 特になし

## 動作確認
1. トップページからEvent一覧を確認
2. EventカードをクリックするとEvent詳細ページへ遷移
3. ログイン状態で出現する「ココロミをつくる」からEvent作成ページへ遷移
4. 作成したEvent内容が有効な場合はEvent一覧ページへ遷移し、無効な場合はメッセージを表示して作成ページに戻る

## その他

- 特になし