### PR TITLE
イベント登録機能追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,3 +61,4 @@ gem 'omniauth-rails_csrf_protection'
 
 gem 'bootstrap-sass'
 gem 'rails-i18n'
+gem "cocoon"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    cocoon (1.2.15)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     devise (4.8.1)
@@ -266,6 +267,7 @@ DEPENDENCIES
   bootstrap-sass
   byebug
   capybara (>= 3.26)
+  cocoon
   devise
   jbuilder (~> 2.7)
   listen (~> 3.3)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ skip_before_action :authenticate_user!, only: :show
 
   def new
     @event = current_user.created_events.build
-    @event.hosted_dates.build
+    3.times { @event.hosted_dates.build }
   end
 
   def create

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,7 @@ skip_before_action :authenticate_user!, only: :show
 
   def new
     @event = current_user.created_events.build
-    3.times { @event.hosted_dates.build }
+    @event.hosted_dates.build
   end
 
   def create
@@ -32,7 +32,7 @@ skip_before_action :authenticate_user!, only: :show
       :required_time,
       :is_published,
       :capacitiy,
-      hosted_dates_attributes: [:start_at, :end_at, :_destroy]
+      hosted_dates_attributes: [:id, :start_at, :end_at, :_destroy]
     )
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,7 @@ skip_before_action :authenticate_user!, only: :show
 
   def new
     @event = current_user.created_events.build
+    @event.hosted_dates.build
   end
 
   def create
@@ -10,8 +11,8 @@ skip_before_action :authenticate_user!, only: :show
 
     if @event.save
       redirect_to @event, notice: "作成しました"
-    else 
-      render 'new'
+    else
+      render :new, alert: "登録できませんでした。入力内容をご確認のうえ再度お試しください"
     end
   end
 
@@ -23,7 +24,15 @@ skip_before_action :authenticate_user!, only: :show
 
   def event_params
     params.require(:event).permit(
-      :name, :place, :title, :discription, :price, :required_time, :is_published, :capacitiy
+      :name,
+      :place,
+      :title,
+      :discription,
+      :price,
+      :required_time,
+      :is_published,
+      :capacitiy,
+      hosted_dates_attributes: [:start_at, :end_at, :_destroy]
     )
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,9 @@ import Turbolinks from "turbolinks"
 import * as ActiveStorage from "@rails/activestorage"
 import "channels"
 
+require("jquery")
+require("@nathanvda/cocoon")
+
 Rails.start()
 Turbolinks.start()
 ActiveStorage.start()

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,5 +1,6 @@
 class Event < ApplicationRecord
   belongs_to :owner, class_name: "User"
+  has_many :hosted_dates
 
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
   belongs_to :owner, class_name: "User"
   has_many :hosted_dates
+  accepts_nested_attributes_for :hosted_dates, allow_destroy: true
 
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -10,6 +10,7 @@ class HostedDate < ApplicationRecord
   def srart_at_should_be_before_end_at
     return unless start_at && end_at
 
+    debugger
     if start_at >= end_at
       errors.add(:start_at, 'は終了時間よりも前に設定してください')
     end

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -1,3 +1,17 @@
 class HostedDate < ApplicationRecord
   belongs_to :event
+
+  validates :start_at, presence: true
+  validates :end_at, presence: true
+  validate :srart_at_should_be_before_end_at
+
+  private
+
+  def srart_at_should_be_before_end_at
+    return unless start_at && end_at
+
+    if start_at >= end_at
+      errors.add(:start_at, 'は終了時間よりも前に設定してください')
+    end
+  end
 end

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -10,7 +10,6 @@ class HostedDate < ApplicationRecord
   def srart_at_should_be_before_end_at
     return unless start_at && end_at
 
-    debugger
     if start_at >= end_at
       errors.add(:start_at, 'は終了時間よりも前に設定してください')
     end

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -1,0 +1,3 @@
+class HostedDate < ApplicationRecord
+  belongs_to :event
+end

--- a/app/views/events/_hosted_date.html.erb
+++ b/app/views/events/_hosted_date.html.erb
@@ -1,0 +1,35 @@
+<div class="row">
+  <div class="col-xs-6">
+    <%= f.label '開催日時' %>
+  </div>
+  <div class="col-xs-6">
+    <div class="text-right">
+      <%= link_to_add_association '開催日時を追加', f, :hosted_dates,
+        class: 'btn btn-default',
+        data: {
+          association_insertion_node: '#detail-association-insertion-point',
+          association_insertion_method: 'append' }
+      %>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="col-sm-12">
+    <table class="table table-list">
+      <thead>
+        <tr>
+          <th>開始</th>
+          <th>終了</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id='detail-association-insertion-point'>
+        <div>
+          <%= f.fields_for :hosted_dates do |date| %>
+          <%= render 'hosted_date_fields', f: date %>
+          <% end %>
+        </div>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/events/_hosted_date_fields.html.erb
+++ b/app/views/events/_hosted_date_fields.html.erb
@@ -1,0 +1,14 @@
+<% today = Date.today %>
+
+<tr class="nested-fields">
+  <%= f.hidden_field :id %>
+  <td>
+  <%= f.datetime_field :start_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600 %>
+  </td>
+  <td>
+  <%= f.datetime_field :end_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
+  </td>
+  <td>
+  <%= link_to_remove_association '削除', f, class: 'btn btn-default' %>
+  </td>
+</tr>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -31,33 +31,18 @@
     <%= f.label :capacitiy %>
     <%= f.text_field :capacitiy, class: "form-control" %>
   </div>
-  <%= f.fields_for :hosted_dates do |date| %>
-    <table id="hosted_date-table">
+  <table id="hosted_date-table" class="form-group">
+    <tr>
+      <th><%= f.label :start_at %></th>
+      <th><%= f.label :end_at %></th>
+    </tr>
+    <%= f.fields_for :hosted_dates do |date| %>
       <tr>
-        <th>
-          <div class="form-group">
-            <%= date.label :start_at %>
-          </div>
-        </th>
-        <th>
-          <div class="form-group">
-            <%= date.label :end_at %>
-          </div>
-        </th>
+        <td><%= date.datetime_field :start_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600 %></td>
+        <td><%= date.datetime_field :end_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600  %></td>
       </tr>
-      <tr>
-        <td>
-          <%= date.datetime_field :start_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600 %>
-          <%# date.datetime_select :start_at, start_year: now.year, end_year: now.year + 1 %>
-        </td>
-        <td>
-          <%= date.datetime_field :end_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
-          <%# date.datetime_select :end_at, start_year: now.year, end_year: now.year + 1 %>
-        </td>
-      </tr>
-
     <% end %>
-    </table>
+  </table>
   <div class="form-group">
     <%= f.label :is_published %>
     <%= f.select :is_published, [['公開', true], ['非公開', false]], {}, { class: "form-control" } %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,38 +1,66 @@
+<% today = Date.today %>
 
 <h1 class="mt-2">ココロミを登録</h1>
-<%= form_with(model: @event, local: true) do |f| %> 
+<%= form_with model: @event, local: true do |f| %>
   <%= render 'shared/error_messages' %>
   <div class="form-group">
-    <%= f.label :name %> 
-    <%= f.text_field :name, class: "form-control" %> 
+    <%= f.label :name %>
+    <%= f.text_field :name, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :title %> 
-    <%= f.text_field :title, class: "form-control" %> 
+    <%= f.label :title %>
+    <%= f.text_field :title, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :discription %> 
-    <%= f.text_area :discription, class: "form-control", row: 10 %> 
+    <%= f.label :discription %>
+    <%= f.text_area :discription, class: "form-control", row: 10 %>
   </div>
   <div class="form-group">
-    <%= f.label :place %> 
-    <%= f.text_field :place, class: "form-control" %> 
+    <%= f.label :place %>
+    <%= f.text_field :place, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :price %> 
-    <%= f.text_field :price, class: "form-control" %> 
+    <%= f.label :price %>
+    <%= f.text_field :price, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :required_time %> 
-    <%= f.text_field :required_time, class: "form-control" %> 
+    <%= f.label :required_time %>
+    <%= f.text_field :required_time, class: "form-control" %>
   </div>
   <div class="form-group">
-    <%= f.label :capacitiy %> 
-    <%= f.text_field :capacitiy, class: "form-control" %> 
+    <%= f.label :capacitiy %>
+    <%= f.text_field :capacitiy, class: "form-control" %>
   </div>
+  <%= f.fields_for :hosted_dates do |date| %>
+    <table id="hosted_date-table">
+      <tr>
+        <th>
+          <div class="form-group">
+            <%= date.label :start_at %>
+          </div>
+        </th>
+        <th>
+          <div class="form-group">
+            <%= date.label :end_at %>
+          </div>
+        </th>
+      </tr>
+      <tr>
+        <td>
+          <%= date.datetime_field :start_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600 %>
+          <%# date.datetime_select :start_at, start_year: now.year, end_year: now.year + 1 %>
+        </td>
+        <td>
+          <%= date.datetime_field :end_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
+          <%# date.datetime_select :end_at, start_year: now.year, end_year: now.year + 1 %>
+        </td>
+      </tr>
+
+    <% end %>
+    </table>
   <div class="form-group">
-    <%= f.label :is_published %> 
+    <%= f.label :is_published %>
     <%= f.select :is_published, [['公開', true], ['非公開', false]], {}, { class: "form-control" } %>
   </div>
-  <%= f.submit class: "btn btn-primary" %> 
-<% end %> 
+  <%= f.submit class: "btn btn-primary" %>
+<% end %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,5 +1,3 @@
-<% today = Date.today %>
-
 <h1 class="mt-2">ココロミを登録</h1>
 <%= form_with model: @event, local: true do |f| %>
   <%= render 'shared/error_messages' %>
@@ -31,18 +29,9 @@
     <%= f.label :capacitiy %> 
     <%= f.text_field :capacitiy, class: 'form-control' %> 
   </div>
-  <table id="hosted_date-table" class="form-group">
-    <tr>
-      <th><%= f.label :start_at %></th>
-      <th><%= f.label :end_at %></th>
-    </tr>
-    <%= f.fields_for :hosted_dates do |date| %>
-      <tr>
-        <td><%= date.datetime_field :start_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600 %></td>
-        <td><%= date.datetime_field :end_at, value: today.strftime('%Y-%m-%dT%T'), min: today.strftime('%Y-%m-%dT%T'), max: today.next_year.strftime('%Y-%m-%dT%T'), step:600  %></td>
-      </tr>
-    <% end %>
-  </table>
+  <div class="form-group">
+    <%= render 'hosted_date', f: f %>
+  </div>
   <div class="form-group">
     <%= f.label :is_published %> 
     <%= f.select :is_published, [['公開', true], ['非公開', false]], {}, { class: 'form-control' } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,7 @@
         <%= render 'layouts/flashes' %>
       <% end %>
       <%= yield %>
+      <%= debug(params) if Rails.env.development? %>
     </div>
   </body>
 </html>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,7 +12,6 @@ ja:
         required_time: 所要時間
         is_published: 公開設定
         capacitiy: 定員
-      hosted_date:
         start_at: 開始日時
         end_at: 終了日時
   devise:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,6 +12,9 @@ ja:
         required_time: 所要時間
         is_published: 公開設定
         capacitiy: 定員
+      hosted_date:
+        start_at: 開始日時
+        end_at: 終了日時
   devise:
     sessions:
       user:

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,11 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+environment.plugins.prepend('Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery/src/jquery',
+        jQuery: 'jquery/src/jquery'
+    })
+)
+
 module.exports = environment

--- a/db/migrate/20221017232859_create_hosted_dates.rb
+++ b/db/migrate/20221017232859_create_hosted_dates.rb
@@ -1,0 +1,11 @@
+class CreateHostedDates < ActiveRecord::Migration[6.1]
+  def change
+    create_table :hosted_dates do |t|
+      t.references :event, null: false, foreign_key: true
+      t.date :start_at, null: false
+      t.date :end_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221019144523_change_datatype_start_at_and_end_at_of_hosted_date.rb
+++ b/db/migrate/20221019144523_change_datatype_start_at_and_end_at_of_hosted_date.rb
@@ -1,0 +1,6 @@
+class ChangeDatatypeStartAtAndEndAtOfHostedDate < ActiveRecord::Migration[6.1]
+  def change
+    change_column :hosted_dates, :start_at, :datetime
+    change_column :hosted_dates, :end_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_17_232859) do
+ActiveRecord::Schema.define(version: 2022_10_19_144523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,8 +33,8 @@ ActiveRecord::Schema.define(version: 2022_10_17_232859) do
 
   create_table "hosted_dates", force: :cascade do |t|
     t.bigint "event_id", null: false
-    t.date "start_at", null: false
-    t.date "end_at", null: false
+    t.datetime "start_at", null: false
+    t.datetime "end_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_id"], name: "index_hosted_dates_on_event_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_16_100238) do
+ActiveRecord::Schema.define(version: 2022_10_17_232859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,15 @@ ActiveRecord::Schema.define(version: 2022_10_16_100238) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["owner_id"], name: "index_events_on_owner_id"
+  end
+
+  create_table "hosted_dates", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.date "start_at", null: false
+    t.date "end_at", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id"], name: "index_hosted_dates_on_event_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -63,4 +72,5 @@ ActiveRecord::Schema.define(version: 2022_10_16_100238) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "hosted_dates", "events"
 end

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "wakuraku",
   "private": true,
   "dependencies": {
+    "@nathanvda/cocoon": "^1.2.14",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.4.3",
+    "jquery": "^3.6.1",
     "turbolinks": "^5.2.0",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/test/fixtures/hosted_dates.yml
+++ b/test/fixtures/hosted_dates.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event: one
+  start_at: 2022-10-18
+  end_at: 2022-10-18
+
+two:
+  event: two
+  start_at: 2022-10-18
+  end_at: 2022-10-18

--- a/test/models/hosted_date_test.rb
+++ b/test/models/hosted_date_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class HostedDateTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,6 +973,13 @@
     "@jridgewell/resolve-uri" "3.1.0"
     "@jridgewell/sourcemap-codec" "1.4.14"
 
+"@nathanvda/cocoon@^1.2.14":
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/@nathanvda/cocoon/-/cocoon-1.2.14.tgz#aaea910e4b9c0d28d5bdcb7f3743617db46b09af"
+  integrity sha512-WcEt2vVp50de2i7rkD4O+96O1iMtMIcTBNGPocrHfcmHDujKOngoLHFF8Ektgoh8PjwFAJMxx8WyGv0BtKTjxQ==
+  dependencies:
+    jquery "^3.3.1"
+
 "@npmcli/fs@^1.0.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@npmcli/fs/-/fs-1.1.1.tgz#72f719fe935e687c56a4faecf3c03d06ba593257"
@@ -3922,6 +3929,11 @@ jest-worker@^26.5.0:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
+
+jquery@^3.3.1, jquery@^3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.1.tgz#fab0408f8b45fc19f956205773b62b292c147a16"
+  integrity sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## やったこと
- HostedDateモデルを追加しEventと関連付け
- cocoonによる複数開催日時の登録機能追加

## やっていないこと（今後実装予定）
- HostedDate閲覧・編集・削除機能

## できるようになること（ユーザ目線）
- Eventと関連した開催日時を登録できるようになる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
1. ログイン状態で出現する「ココロミをつくる」からEvent作成ページへ遷移
2. 必要事項を入力し開催日時フィールド内のセレクトボタンから開始と終了の日時を選択する
3. 必要に応じて開催日時をボタンにより追加、削除する
4. 登録後、Railsコンソール内でイベントと開催日時が関連して登録されていることを確認する。
```
$ rails c
$ event = Event.last
$ event.hosted_dates
```

## その他
- 特になし