### PR TITLE
カラム名変更（events, hosted_dates)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -33,7 +33,7 @@ skip_before_action :authenticate_user!, only: :show
       :required_time,
       :is_published,
       :capacity,
-      hosted_dates_attributes: [:id, :start_at, :end_at, :_destroy]
+      hosted_dates_attributes: [:id, :started_at, :ended_at, :_destroy]
     )
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -32,7 +32,7 @@ skip_before_action :authenticate_user!, only: :show
       :price,
       :required_time,
       :is_published,
-      :capacitiy,
+      :capacity,
       hosted_dates_attributes: [:id, :start_at, :end_at, :_destroy]
     )
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,7 +9,7 @@ class Event < ApplicationRecord
   validates :discription, length: { maximum: 2000 }, presence: true
   validates :price, length: { maximum: 7 }, presence: true
   validates :required_time, length: { maximum: 3 }, presence: true
-  validates :capacitiy, length: { maximum: 3 }, presence: true
+  validates :capacity, length: { maximum: 3 }, presence: true
   validates :is_published, inclusion: {in: [true, false]}
 
   scope :with_dates, -> { eager_load(:hosted_dates) }

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -1,17 +1,17 @@
 class HostedDate < ApplicationRecord
   belongs_to :event
 
-  validates :start_at, presence: true
-  validates :end_at, presence: true
-  validate :srart_at_should_be_before_end_at
+  validates :started_at, presence: true
+  validates :ended_at, presence: true
+  validate :srart_at_should_be_before_ended_at
 
   private
 
-  def srart_at_should_be_before_end_at
-    return unless start_at && end_at
+  def srart_at_should_be_before_ended_at
+    return unless started_at && ended_at
 
-    if start_at >= end_at
-      errors.add(:start_at, 'は終了時間よりも前に設定してください')
+    if started_at >= ended_at
+      errors.add(:started_at, 'は終了時間よりも前に設定してください')
     end
   end
 end

--- a/app/views/events/_event_item.html.erb
+++ b/app/views/events/_event_item.html.erb
@@ -3,7 +3,7 @@
   <p class="mb-1"><%= event.title %> </p>
   <ul>
     <% event.hosted_dates.each do |date| %>
-      <li s class="mb-1"><%= l(date.start_at, format: :long) %> - <%= l(date.end_at, format: :long) %></li>
+      <li s class="mb-1"><%= l(date.started_at, format: :long) %> - <%= l(date.ended_at, format: :long) %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/events/_hosted_date_fields.html.erb
+++ b/app/views/events/_hosted_date_fields.html.erb
@@ -1,10 +1,10 @@
 <tr class="nested-fields">
   <%= f.hidden_field :id %>
   <td>
-  <%= f.datetime_field :start_at, value: @today.strftime('%Y-%m-%dT%T'), min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600 %>
+  <%= f.datetime_field :started_at, value: @today.strftime('%Y-%m-%dT%T'), min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600 %>
   </td>
   <td>
-  <%= f.datetime_field :end_at, value: @today.strftime('%Y-%m-%dT%T'), min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
+  <%= f.datetime_field :ended_at, value: @today.strftime('%Y-%m-%dT%T'), min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
   </td>
   <td>
   <%= link_to_remove_association '削除', f, class: 'btn btn-default' %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -26,8 +26,8 @@
     <%= f.text_field :required_time, class: 'form-control' %> 
   </div>
   <div class="form-group">
-    <%= f.label :capacitiy %> 
-    <%= f.text_field :capacitiy, class: 'form-control' %> 
+    <%= f.label :capacity %> 
+    <%= f.text_field :capacity, class: 'form-control' %> 
   </div>
   <div class="form-group">
     <%= render 'hosted_date', f: f %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,7 +11,7 @@ ja:
         price: 価格
         required_time: 所要時間
         is_published: 公開設定
-        capacitiy: 定員
+        capacity: 定員
         start_at: 開始日時
         end_at: 終了日時
   devise:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -12,8 +12,8 @@ ja:
         required_time: 所要時間
         is_published: 公開設定
         capacity: 定員
-        start_at: 開始日時
-        end_at: 終了日時
+        started_at: 開始日時
+        ended_at: 終了日時
   devise:
     sessions:
       user:

--- a/db/migrate/20221016100238_create_events.rb
+++ b/db/migrate/20221016100238_create_events.rb
@@ -10,7 +10,7 @@ class CreateEvents < ActiveRecord::Migration[6.1]
       t.integer :price, null: false
       t.integer :required_time, null: false
       t.boolean :is_published, null: false
-      t.integer :capacitiy, null: false
+      t.integer :capacity, null: false
 
       t.timestamps
     end

--- a/db/migrate/20221017232859_create_hosted_dates.rb
+++ b/db/migrate/20221017232859_create_hosted_dates.rb
@@ -2,8 +2,8 @@ class CreateHostedDates < ActiveRecord::Migration[6.1]
   def change
     create_table :hosted_dates do |t|
       t.references :event, null: false, foreign_key: true
-      t.date :start_at, null: false
-      t.date :end_at, null: false
+      t.date :started_at, null: false
+      t.date :ended_at, null: false
 
       t.timestamps
     end

--- a/db/migrate/20221019144523_change_datatype_start_at_and_end_at_of_hosted_date.rb
+++ b/db/migrate/20221019144523_change_datatype_start_at_and_end_at_of_hosted_date.rb
@@ -1,6 +1,6 @@
 class ChangeDatatypeStartAtAndEndAtOfHostedDate < ActiveRecord::Migration[6.1]
   def change
-    change_column :hosted_dates, :start_at, :datetime
-    change_column :hosted_dates, :end_at, :datetime
+    change_column :hosted_dates, :started_at, :datetime
+    change_column :hosted_dates, :ended_at, :datetime
   end
 end

--- a/db/migrate/20221102142554_rename_capacitiy_column_to_events.rb
+++ b/db/migrate/20221102142554_rename_capacitiy_column_to_events.rb
@@ -1,0 +1,5 @@
+class RenamecapacityColumnToEvents < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :events, :capacity, :capacity
+  end
+end

--- a/db/migrate/20221102143139_rename_start_at_and_end_at_column_to_hosted_dates.rb
+++ b/db/migrate/20221102143139_rename_start_at_and_end_at_column_to_hosted_dates.rb
@@ -1,0 +1,6 @@
+class RenameStartAtAndEndAtColumnToHostedDates < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :hosted_dates, :started_at, :started_at
+    rename_column :hosted_dates, :ended_at, :ended_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_02_142554) do
+ActiveRecord::Schema.define(version: 2022_11_02_143139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,8 +33,8 @@ ActiveRecord::Schema.define(version: 2022_11_02_142554) do
 
   create_table "hosted_dates", force: :cascade do |t|
     t.bigint "event_id", null: false
-    t.datetime "start_at", null: false
-    t.datetime "end_at", null: false
+    t.datetime "started_at", null: false
+    t.datetime "ended_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_id"], name: "index_hosted_dates_on_event_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_19_144523) do
+ActiveRecord::Schema.define(version: 2022_11_02_142554) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2022_10_19_144523) do
     t.integer "price", null: false
     t.integer "required_time", null: false
     t.boolean "is_published", null: false
-    t.integer "capacitiy", null: false
+    t.integer "capacity", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["owner_id"], name: "index_events_on_owner_id"

--- a/hello.pu
+++ b/hello.pu
@@ -62,7 +62,7 @@ entity "events" as events {
   required_time
   place
   is_published
-  capacitiy
+  capacity
   created_at
   updated_at
   deleted_at

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -11,7 +11,7 @@ one:
   price: 1
   required_time: 1
   is_published: false
-  capacitiy: 1
+  capacity: 1
 
 two:
   owner_id: 
@@ -24,4 +24,4 @@ two:
   price: 1
   required_time: 1
   is_published: false
-  capacitiy: 1
+  capacity: 1

--- a/test/fixtures/hosted_dates.yml
+++ b/test/fixtures/hosted_dates.yml
@@ -2,10 +2,10 @@
 
 one:
   event: one
-  start_at: 2022-10-18
-  end_at: 2022-10-18
+  started_at: 2022-10-18
+  ended_at: 2022-10-18
 
 two:
   event: two
-  start_at: 2022-10-18
-  end_at: 2022-10-18
+  started_at: 2022-10-18
+  ended_at: 2022-10-18


### PR DESCRIPTION
## やったこと
- eventsのカラム名を修正 ( capacitiy => capacity )
- hosted_datesのカラム名を修正 ( start_at => started_at, end_at => ended_at )
- カラム名変更に伴う呼び出し部の修正

## やっていないこと（今後実装予定）
- 特になし

## できるようになること（開発者目線）
- 可読性向上

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- capacityの登録、閲覧ができること
- started_at, ended_atの登録、閲覧ができること

## その他
- 特になし