### PR TITLE
イベントページへ開催日情報を追加

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -38,16 +38,8 @@ body .container {
   // ここまで
 }
 
-.detail-section {
+.detail-section, .dates-section {
   background-color: #f5f5f5;
-  .discription {
-    margin: 0 auto;
-    margin-bottom: 40px;
-    width: fit-content;
-    .detail-text {
-      line-height: 1.8;
-    }
-  }
   table  {
     margin: 0 auto;
     th, td{
@@ -64,11 +56,36 @@ body .container {
         margin-right: 10px;
       }
     }
+  }
+}
+
+.detail-section {
+  .discription {
+    margin: 0 auto;
+    margin-bottom: 40px;
+    width: fit-content;
+    .detail-text {
+      line-height: 1.8;
+      table  {
+        td {
+          span.unit {
+            margin-left: 5px;
+            font-size: 1.3rem;
+            color: rgb(93, 91, 91);
+          }
+        }
+      }
+    }
+  }
+}
+
+.dates-section {
+  table  {
     td {
-      span.unit {
+      span.rest-capacity {
         margin-left: 5px;
-        font-size: 1.3rem;
-        color: rgb(93, 91, 91);
+        font-size: 0.9rem;
+        color: rgb(109, 105, 105);
       }
     }
   }

--- a/app/views/events/_hosted_date_show.html.erb
+++ b/app/views/events/_hosted_date_show.html.erb
@@ -1,0 +1,14 @@
+<tr>
+  <th>
+    <%= icon('far', 'calendar-days', class: 'detail-icon')%>
+    <%= l(date.started_at, format: :long) %> - <%= l(date.ended_at, format: :short) %>
+  </th>
+  <!-- TODO: 後で実装--------- -->
+  <td>
+    ◯<span class="rest-capacity">残り1人</span>
+  </td>
+  <td>
+    <%= link_to '予約する', '#', class: "btn btn-default" %>
+  </td>
+  <!-- ---------------ここまで -->
+</tr>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -51,6 +51,29 @@
     </table>
   </div>
 </div>
+<div class="dates-section">
+  <div class="wrapper">
+    <h2 class="section-header">開催日から予約</h2>
+    <table>
+      <% @event.hosted_dates.each do |date| %>
+        <tr>
+          <th>
+            <%= icon('far', 'calendar-days', class: 'detail-icon')%>
+            <%= l(date.started_at, format: :long) %> - <%= l(date.ended_at, format: :short) %>
+          </th>
+          <!-- TODO: 後で実装--------- -->
+          <td>
+            ◯<span class="rest-capacity">残り1人</span>
+          </td>
+          <td>
+            <%= link_to '予約する', '#', class: "btn btn-default" %>
+          </td>
+          <!-- ---------------ここまで -->
+        </tr>
+      <% end %>
+    </table>
+  </div>
+</div>
 <div class="owner-section">
   <div class="wrapper">
     <h2 class="section-header">作家さん</h2>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -55,22 +55,7 @@
   <div class="wrapper">
     <h2 class="section-header">開催日から予約</h2>
     <table>
-      <% @event.hosted_dates.each do |date| %>
-        <tr>
-          <th>
-            <%= icon('far', 'calendar-days', class: 'detail-icon')%>
-            <%= l(date.started_at, format: :long) %> - <%= l(date.ended_at, format: :short) %>
-          </th>
-          <!-- TODO: 後で実装--------- -->
-          <td>
-            ◯<span class="rest-capacity">残り1人</span>
-          </td>
-          <td>
-            <%= link_to '予約する', '#', class: "btn btn-default" %>
-          </td>
-          <!-- ---------------ここまで -->
-        </tr>
-      <% end %>
+      <%= render partial: 'hosted_date_show', collection: @event.hosted_dates, as: 'date' %>
     </table>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,4 +22,7 @@ ja:
     omniauth_callbacks:
       user:
         success: ログインしました
+  time:
+    formats:
+      short: "%H:%M"
 


### PR DESCRIPTION
## やったこと
- イベント詳細ページに開催日情報を反映
- cssを修正

## やっていないこと（今後実装予定）
- 残り予約可能人数の表示
- 予約確認ページへのリンク付与

## できるようになること（ユーザー）
- イベントが持っている開催日を確認できるようになる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- イベントページで登録された開催日が閲覧できることを確認

## その他
- 特になし