### PR TITLE
イベント編集・削除機能を追加

### DIFF
--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -26,6 +26,10 @@ body .container {
 }
 
 .eye-catching {
+  .event-header {
+    display: flex;
+    justify-content: space-between;
+  }
   // Todo: 画像読み機能実装後修正
   .images-box {
     background-image: image-url('workshop.jpeg');

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,13 +4,17 @@ class EventsController < ApplicationController
           hosted_dates_attributes: 
             [:id, :started_at, :ended_at, :_destroy]
 
+  def index
+    @events = Event.with_recent_dates
+  end
+
   def new
     @event = current_user.created_events.build
     @event.hosted_dates.build
     @today = Date.today
   end
 
-  def create(event)
+  def create(event:)
     @event = current_user.created_events.build(event)
 
     if @event.save
@@ -20,7 +24,25 @@ class EventsController < ApplicationController
     end
   end
 
-  def show(id)
+  def show(id:)
     @event = Event.find(id)
+  end
+
+  def edit(id:)
+    @event = current_user.created_events.find(id)
+    @today = Date.today
+  end
+
+  def update(id:, event:)
+    @event = current_user.created_events.find(id)
+    if @event.update(event)
+      redirect_to @event, notice: '更新しました'
+    end
+  end
+
+  def destroy(id:)
+    @event = current_user.created_events.find(id)
+    @event.destroy!
+    redirect_to events_path, notice: '削除しました'
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 class Event < ApplicationRecord
   belongs_to :owner, class_name: 'User'
-  has_many :hosted_dates
+  has_many :hosted_dates, dependent: :destroy
   accepts_nested_attributes_for :hosted_dates, allow_destroy: true
 
   validates :name, length: { maximum: 50 }, presence: true
@@ -17,4 +17,9 @@ class Event < ApplicationRecord
   scope :sorted, -> { order(updated_at: :desc) }
   scope :with_recent_dates, -> { with_dates.published.sorted }
   scope :recent, -> { published.sorted }
+
+  def created_by?(user)
+    return false unless user
+    owner.id == user.id
+  end
 end

--- a/app/views/events/_hosted_date_fields.html.erb
+++ b/app/views/events/_hosted_date_fields.html.erb
@@ -1,10 +1,10 @@
 <tr class="nested-fields">
   <%= f.hidden_field :id %>
   <td>
-  <%= f.datetime_field :started_at, value: @today.strftime('%Y-%m-%dT%T'), min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600 %>
+  <%= f.datetime_field :started_at, min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600 %>
   </td>
   <td>
-  <%= f.datetime_field :ended_at, value: @today.strftime('%Y-%m-%dT%T'), min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
+  <%= f.datetime_field :ended_at, min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
   </td>
   <td>
   <%= link_to_remove_association '削除', f, class: 'btn btn-default' %>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,40 @@
+<h1 class="mt-2">ココロミを更新</h1>
+<%= form_with model: @event, local: true do |f| %>
+  <%= render 'shared/error_messages' %>
+  <div class="form-group">
+    <%= f.label :name %> 
+    <%= f.text_field :name, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :title %> 
+    <%= f.text_field :title, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :discription %> 
+    <%= f.text_area :discription, class: 'form-control', row: 10 %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :place %> 
+    <%= f.text_field :place, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :price %> 
+    <%= f.text_field :price, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :required_time %> 
+    <%= f.text_field :required_time, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :capacity %> 
+    <%= f.text_field :capacity, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= render 'hosted_date', f: f %>
+  </div>
+  <div class="form-group">
+    <%= f.label :is_published %> 
+    <%= f.select :is_published, [['公開', true], ['非公開', false]], {}, { class: 'form-control' } %>
+  </div>
+  <%= f.submit class: 'btn btn-primary' %> 
+<% end %> 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,5 @@
+<h1>ココロミ一覧</h1>
+
+<div class="list-group">
+  <%= render partial: 'event_item', collection: @events, as: 'event' %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,6 +1,14 @@
 <div class="eye-catching">
   <div class="wrapper">
-    <h1><%= @event.name %> </h1>
+    <div class="event-header">
+      <h1><%= @event.name %> </h1>
+      <div class="btn-space">
+        <% if @event.created_by?(current_user) %> 
+          <%= link_to '編集する', edit_event_path(@event), class: 'btn btn-default' %> 
+          <%= link_to '削除する', event_path(@event), class: 'btn btn-danger', method: :delete, data: { confirm: '本当に削除しますか？' } %> 
+        <% end %> 
+      </div>
+    </div>
     <div class="images-box">
       <div class="image-box"></div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :events
   root 'home#index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  resources :events
 end


### PR DESCRIPTION
## やったこと
- イベント編集・削除機能を追加
- イベント一覧表示ページを追加
- ActionArgs記法を修正
- ルーティング記載順を変更

## やっていないこと（今後実装予定）
- 特になし

## できるようになること（ユーザー目線）
- イベントを編集・削除できるようになる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- `/events`内でイベント一覧が表示できること
- イベントを作ったユーザーのみ、イベント詳細ページに編集ボタン・削除ボタンが出現すること
- 編集画面で編集した内容が更新され、イベント詳細ページに遷移すること
- 削除ボタンで確認ダイアログが出現し、「はい」を押下するとイベント情報が削除され、イベント一覧ページに遷移すること
- 削除されたイベントに紐づく開催日情報も同時に削除されていること

## その他
- 特になし