### PR TITLE
希望するイベント・日時への予約機能を追加

### DIFF
--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the reservations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,20 +1,18 @@
 class ReservationsController < ApplicationController
+  before_action :set_event_and_date, only: [:new, :create]
   permits :comment
-
-  def new(event_id:, date_id:)
-    @event = Event.find(event_id)
-    @date = HostedDate.find(date_id)
+  
+  def new
     @reservation = current_user.reservations.build
   end
-
-  def create(event_id:, date_id:, reservation:)
-    @event = Event.find(event_id)
-    date = HostedDate.find(date_id)
+  
+  def create(reservation:)
     @reservation = current_user.reservations.build(reservation) do |t|
       t.event = @event
-      t.hosted_date = date
+      t.hosted_date = @date
     end
-
+    
+    debugger
     if @reservation.save
       # TODO: 参加したイベント一覧実装後は遷移先を変更する
       redirect_to root_path, notice: 'イベントに参加しました'
@@ -22,5 +20,12 @@ class ReservationsController < ApplicationController
       flash.now[:error] = 'イベントに参加できませんでした'
       render 'events/show'
     end
+  end
+
+  private 
+  
+  def set_event_and_date(event_id:, date_id:)
+    @event = Event.find(event_id)
+    @date = HostedDate.find(date_id)
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,16 +1,18 @@
 class ReservationsController < ApplicationController
+  permits :comment
+
   def new(event_id:, date_id:)
     @event = Event.find(event_id)
     @date = HostedDate.find(date_id)
     @reservation = current_user.reservations.build
   end
 
-  def create(event_id:, date_id:)
+  def create(event_id:, date_id:, reservation:)
     event = Event.find(event_id)
     date = HostedDate.find(date_id)
-    @reservation = current_user.reservations.build do |t|
+    @reservation = current_user.reservations.build(reservation) do |t|
       t.event = event
-      t.comment = params[:reservation][:comment]
+      t.hosted_date = date
     end
 
     if @reservation.save

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,0 +1,16 @@
+class ReservationsController < ApplicationController
+  def new
+  end
+
+  def create(id:)
+    event = Event.find(id)
+    @reservation = current_user.reservations.build do |t|
+      t.event = event
+      t.comment = params[:reservation][:comment]
+    end
+
+    if @reservation.save
+      redirect_to event, notice: 'イベントに参加しました'
+    end
+  end
+end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -16,11 +16,11 @@ class ReservationsController < ApplicationController
     end
 
     if @reservation.save
+      # TODO: 参加したイベント一覧実装後は遷移先を変更する
       redirect_to root_path, notice: 'イベントに参加しました'
     else
       flash.now[:error] = 'イベントに参加できませんでした'
       render 'events/show'
-      # render 'events/show', notice: "この日時(#{l(date.started_at, format: :long)}-#{l(date.ended_at, format: :short)})には参加できません"
     end
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,16 +1,20 @@
 class ReservationsController < ApplicationController
-  def new
+  def new(event_id:, date_id:)
+    @event = Event.find(event_id)
+    @date = HostedDate.find(date_id)
+    @reservation = current_user.reservations.build
   end
 
-  def create(id:)
-    event = Event.find(id)
+  def create(event_id:, date_id:)
+    event = Event.find(event_id)
+    date = HostedDate.find(date_id)
     @reservation = current_user.reservations.build do |t|
       t.event = event
       t.comment = params[:reservation][:comment]
     end
 
     if @reservation.save
-      redirect_to event, notice: 'イベントに参加しました'
+      redirect_to root_path, notice: 'イベントに参加しました'
     end
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -8,15 +8,19 @@ class ReservationsController < ApplicationController
   end
 
   def create(event_id:, date_id:, reservation:)
-    event = Event.find(event_id)
+    @event = Event.find(event_id)
     date = HostedDate.find(date_id)
     @reservation = current_user.reservations.build(reservation) do |t|
-      t.event = event
+      t.event = @event
       t.hosted_date = date
     end
 
     if @reservation.save
       redirect_to root_path, notice: 'イベントに参加しました'
+    else
+      flash.now[:error] = 'イベントに参加できませんでした'
+      render 'events/show'
+      # render 'events/show', notice: "この日時(#{l(date.started_at, format: :long)}-#{l(date.ended_at, format: :short)})には参加できません"
     end
   end
 end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -12,7 +12,6 @@ class ReservationsController < ApplicationController
       t.hosted_date = @date
     end
     
-    debugger
     if @reservation.save
       # TODO: 参加したイベント一覧実装後は遷移先を変更する
       redirect_to root_path, notice: 'イベントに参加しました'

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,0 +1,2 @@
+module ReservationsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,7 @@
 class Event < ApplicationRecord
   belongs_to :owner, class_name: 'User'
   has_many :hosted_dates, dependent: :destroy
+  has_many :reservations
   accepts_nested_attributes_for :hosted_dates, allow_destroy: true
 
   validates :name, length: { maximum: 50 }, presence: true

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -1,5 +1,6 @@
 class HostedDate < ApplicationRecord
   belongs_to :event
+  has_many :reservations
 
   validates :started_at, presence: true
   validates :ended_at, presence: true

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,0 +1,4 @@
+class Reservation < ApplicationRecord
+  belongs_to :user
+  belongs_to :event
+end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -4,9 +4,9 @@ class Reservation < ApplicationRecord
   belongs_to :hosted_date
 
   validates :comment, length: { maximum: 200 }, allow_blank: true
-  with_options uniqueness: true, presence: true do
+  with_options presence: true do
     validates :user_id
     validates :event_id
-    validates :hosted_date_id
+    validates :hosted_date_id, uniqueness: true 
   end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,6 +1,7 @@
 class Reservation < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :event
+  belongs_to :hosted_date
 
   validates :comment, length: { maximum: 200 }, allow_blank: true
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -4,4 +4,9 @@ class Reservation < ApplicationRecord
   belongs_to :hosted_date
 
   validates :comment, length: { maximum: 200 }, allow_blank: true
+  with_options uniqueness: true, presence: true do
+    validates :user_id
+    validates :event_id
+    validates :hosted_date_id
+  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -1,4 +1,6 @@
 class Reservation < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, optional: true
   belongs_to :event
+
+  validates :comment, length: { maximum: 200 }, allow_blank: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,10 @@
 class User < ApplicationRecord
+  has_many :created_events, class_name: 'Event', foreign_key: 'owner_id'
+  has_many :reservations
+  devise :database_authenticatable, :registerable,
+  :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook]
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  has_many :created_events, class_name: 'Event', foreign_key: 'owner_id'
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook]
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/events/_hosted_date_show.html.erb
+++ b/app/views/events/_hosted_date_show.html.erb
@@ -8,7 +8,7 @@
     ◯<span class="rest-capacity">残り1人</span>
   </td>
   <td>
-    <%= link_to '予約する', '#', class: "btn btn-default" %>
+    <%= link_to '予約する', new_event_reservation_path(event_id: date.event, date_id: date), class: "btn btn-default" %>
   </td>
   <!-- ---------------ここまで -->
 </tr>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -63,7 +63,7 @@
   <div class="wrapper">
     <h2 class="section-header">開催日から予約</h2>
     <table>
-      <%= render partial: 'hosted_date_show', collection: @event.hosted_dates, as: 'date' %>
+      <%= render partial: 'events/hosted_date_show', collection: @event.hosted_dates, as: 'date' %>
     </table>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,7 +13,7 @@
   <body>
     <%= render 'layouts/header' %>
     <div class="container">
-      <% if flash[:notice] %> 
+      <% if flash.any?%> 
         <%= render 'layouts/flashes' %>
       <% end %>
       <%= yield %>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,0 +1,48 @@
+<%= render 'shared/error_messages' %>
+<h1>ご予約内容確認</h1>
+<div class="detail-section">
+  <div class="wrapper">
+    <h2 class="section-header">ご予約内容</h2>
+    <table>
+      <tr>
+        <th><%= icon('fas', 'location-dot', class: 'detail-icon')%>プラン名</th>
+        <td><%= @event.name %></td>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'stopwatch', class: 'detail-icon')%>日時</th>
+        <th><%= l(@date.started_at, format: :long) %> - <%= l(@date.ended_at, format: :short) %></th>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'users', class: 'detail-icon')%>参加者数</h3></th>
+        <td><%= @event.required_time %><span class="unit">人</span></td>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'yen-sign', class: 'detail-icon')%>参加費計</th>
+        <td><%= @event.price %><span class="unit">円</span></td>
+      </tr>
+    </table>
+  </div>
+</div>
+<div class="detail-section">
+  <div class="wrapper">
+    <h2 class="section-header">お客様情報</h2>
+    <table>
+      <tr>
+        <th><%= icon('fas', 'stopwatch', class: 'detail-icon')%>お名前</th>
+        <td><%= @reservation.user.name %></td>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'location-dot', class: 'detail-icon')%>e-mail</th>
+        <td><%= @reservation.user.email %></td>
+      </tr>
+    </tr>
+  </table>
+  <%= form_with model: @reservation, url: event_reservations_path(event_id: @event, date_id: @date), local: true do |f| %>
+    <div class="form-group">
+      <%= f.label :comment %>
+      <%= f.text_area :comment, class: 'form-control', row: 10 %>
+    </div>
+    <%= f.submit '予約を確定する', class: 'btn btn-primary' %> 
+  <% end %> 
+  </div>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -14,6 +14,8 @@ ja:
         capacity: 定員
         started_at: 開始日時
         ended_at: 終了日時
+      reservation:
+        comment: 連絡事項
   devise:
     sessions:
       user:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
   root 'home#index'
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
-  resources :events
+  resources :events do
+    resources :reservations
+  end
 end

--- a/db/migrate/20221108034858_create_reservations.rb
+++ b/db/migrate/20221108034858_create_reservations.rb
@@ -5,7 +5,7 @@ class CreateReservations < ActiveRecord::Migration[6.1]
       t.references :event, null: false, foreign_key: true, index: false
       t.string :comment
       t.integer :guest_number
-      t.boolean :is_canceled
+      t.boolean :is_canceled, default: false
       t.timestamps
     end
 

--- a/db/migrate/20221108034858_create_reservations.rb
+++ b/db/migrate/20221108034858_create_reservations.rb
@@ -3,12 +3,13 @@ class CreateReservations < ActiveRecord::Migration[6.1]
     create_table :reservations do |t|
       t.references :user
       t.references :event, null: false, foreign_key: true, index: false
+      t.references :hosted_date, null: false, foreign_key: true, index: false
       t.string :comment
       t.integer :guest_number
       t.boolean :is_canceled, default: false
       t.timestamps
     end
 
-    add_index :reservations, %i[event_id user_id], unique: true
+    add_index :reservations, %i[event_id user_id hosted_date_id], unique: true
   end
 end

--- a/db/migrate/20221108034858_create_reservations.rb
+++ b/db/migrate/20221108034858_create_reservations.rb
@@ -1,0 +1,14 @@
+class CreateReservations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :reservations do |t|
+      t.references :user
+      t.references :event, null: false, foreign_key: true, index: false
+      t.string :comment
+      t.integer :guest_number
+      t.boolean :is_canceled
+      t.timestamps
+    end
+
+    add_index :reservations, %i[event_id user_id], unique: true
+  end
+end

--- a/db/migrate/20221109150407_add_reference_to_reservations.rb
+++ b/db/migrate/20221109150407_add_reference_to_reservations.rb
@@ -1,6 +1,0 @@
-class AddReferenceToReservations < ActiveRecord::Migration[6.1]
-  def change
-    add_reference  :reservations, :hosted_date, null: false, foreign_key: true, default: 14
-    change_column_default  :reservations, :hosted_date_id, from: 14, to: nil
-  end
-end

--- a/db/migrate/20221109150407_add_reference_to_reservations.rb
+++ b/db/migrate/20221109150407_add_reference_to_reservations.rb
@@ -1,0 +1,6 @@
+class AddReferenceToReservations < ActiveRecord::Migration[6.1]
+  def change
+    add_reference  :reservations, :hosted_date, null: false, foreign_key: true, default: 14
+    change_column_default  :reservations, :hosted_date_id, from: 14, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_02_143139) do
+ActiveRecord::Schema.define(version: 2022_11_08_034858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2022_11_02_143139) do
     t.integer "price", null: false
     t.integer "required_time", null: false
     t.boolean "is_published", null: false
-    t.integer "capacitiy", null: false
+    t.integer "capacity", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["owner_id"], name: "index_events_on_owner_id"
@@ -33,11 +33,23 @@ ActiveRecord::Schema.define(version: 2022_11_02_143139) do
 
   create_table "hosted_dates", force: :cascade do |t|
     t.bigint "event_id", null: false
-    t.datetime "start_at", null: false
-    t.datetime "end_at", null: false
+    t.datetime "started_at", null: false
+    t.datetime "ended_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_id"], name: "index_hosted_dates_on_event_id"
+  end
+
+  create_table "reservations", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "event_id", null: false
+    t.string "comment"
+    t.integer "guest_number"
+    t.boolean "is_canceled"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["event_id", "user_id"], name: "index_reservations_on_event_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -73,4 +85,5 @@ ActiveRecord::Schema.define(version: 2022_11_02_143139) do
   end
 
   add_foreign_key "hosted_dates", "events"
+  add_foreign_key "reservations", "events"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_08_034858) do
+ActiveRecord::Schema.define(version: 2022_11_09_150407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,7 +48,9 @@ ActiveRecord::Schema.define(version: 2022_11_08_034858) do
     t.boolean "is_canceled", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "hosted_date_id", null: false
     t.index ["event_id", "user_id"], name: "index_reservations_on_event_id_and_user_id", unique: true
+    t.index ["hosted_date_id"], name: "index_reservations_on_hosted_date_id"
     t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 
@@ -86,4 +88,5 @@ ActiveRecord::Schema.define(version: 2022_11_08_034858) do
 
   add_foreign_key "hosted_dates", "events"
   add_foreign_key "reservations", "events"
+  add_foreign_key "reservations", "hosted_dates"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_09_150407) do
+ActiveRecord::Schema.define(version: 2022_11_08_034858) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,14 +43,13 @@ ActiveRecord::Schema.define(version: 2022_11_09_150407) do
   create_table "reservations", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "event_id", null: false
+    t.bigint "hosted_date_id", null: false
     t.string "comment"
     t.integer "guest_number"
     t.boolean "is_canceled", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "hosted_date_id", null: false
-    t.index ["event_id", "user_id"], name: "index_reservations_on_event_id_and_user_id", unique: true
-    t.index ["hosted_date_id"], name: "index_reservations_on_hosted_date_id"
+    t.index ["event_id", "user_id", "hosted_date_id"], name: "index_reservations_on_event_id_and_user_id_and_hosted_date_id", unique: true
     t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 2022_11_08_034858) do
     t.bigint "event_id", null: false
     t.string "comment"
     t.integer "guest_number"
-    t.boolean "is_canceled"
+    t.boolean "is_canceled", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["event_id", "user_id"], name: "index_reservations_on_event_id_and_user_id", unique: true

--- a/test/controllers/reservations_controller_test.rb
+++ b/test/controllers/reservations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReservationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/reservations.yml
+++ b/test/fixtures/reservations.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  event: one
+  comment: MyString
+  guest_number: 1
+  is_canceled: false
+
+two:
+  user: two
+  event: two
+  comment: MyString
+  guest_number: 1
+  is_canceled: false

--- a/test/models/reservation_test.rb
+++ b/test/models/reservation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReservationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## やったこと
- イベント予約機能を実装
  - ReservationのMVCを作成しルーティング設定
  - アソシエーションを追加 (User, Event, HostedDate)
- notice以外のフラッシュメッセージを表示できるよう修正 

## やっていないこと（今後実装予定）
- イベント予約が失敗した時のエラーメッセージ表示
- 予約一覧表示
- 参加人数登録機能

## できるようになること（ユーザー目線）
- 希望するイベント・日時へ予約登録ができるようになる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- ログイン状態でイベント詳細ページ/events/:idから希望する日時の「予約する」を押下すると予約確認画面に遷移する
- 予約確認画面で選択したイベントと日時情報が確認できること
- 連絡事項を入力し（任意）「予約を確定する」を押下すると、「イベントに参加しました」と表示されトップページへ遷移する。その際、関連するuser_id, event_id, hosted_idを持ったReservationがcreateされる
- 同じユーザーが既に登録したイベントと日時の組み合わせで「予約を確定する」を押下すると、「イベントに参加できませんでした」と表示され、イベント詳細ページがレンダリングされる。その際、transactionがrollbackされる
- ログインしていない状態で「予約する」を押下するとログインページへ遷移し、ログインするとイベント詳細ページに遷移する。