### PR TITLE
バリデーション失敗時のメッセージ表示周りを改善

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
   skip_before_action :authenticate_user!, only: :show
-  permits :name, :place, :title, :discription, :price, :required_time, :is_published, :capacity, 
-          hosted_dates_attributes: 
+  permits :name, :place, :title, :discription, :price, :required_time, :is_published, :capacity,
+          hosted_dates_attributes:
             [:id, :started_at, :ended_at, :_destroy]
 
   def index
@@ -19,7 +19,8 @@ class EventsController < ApplicationController
 
     if @event.save
       redirect_to @event, notice: '作成しました'
-    else 
+    else
+      @today = Date.today
       render 'new'
     end
   end
@@ -37,6 +38,9 @@ class EventsController < ApplicationController
     @event = current_user.created_events.find(id)
     if @event.update(event)
       redirect_to @event, notice: '更新しました'
+    else
+      @today = Date.today
+      render 'edit'
     end
   end
 

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -13,10 +13,10 @@ class ReservationsController < ApplicationController
     end
     
     if @reservation.save
-      # TODO: 参加したイベント一覧実装後は遷移先を変更する
-      redirect_to root_path, notice: 'イベントに参加しました'
+      # TODO: 参加したココロミ一覧実装後は遷移先を変更する
+      redirect_to root_path, notice: 'ココロミを予約しました'
     else
-      flash.now[:error] = 'イベントに参加できませんでした'
+      flash.now[:error] = 'ココロミを予約できませんでした'
       render 'events/show'
     end
   end

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,6 +1,6 @@
 <h1 class="mt-2">ココロミを更新</h1>
 <%= form_with model: @event, local: true do |f| %>
-  <%= render 'shared/error_messages' %>
+  <%= render 'shared/error_messages', model: f.object %>
   <div class="form-group">
     <%= f.label :name %> 
     <%= f.text_field :name, class: 'form-control' %> 

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,6 +1,6 @@
 <h1 class="mt-2">ココロミを登録</h1>
 <%= form_with model: @event, local: true do |f| %>
-  <%= render 'shared/error_messages' %>
+  <%= render 'shared/error_messages', model: f.object %>
   <div class="form-group">
     <%= f.label :name %> 
     <%= f.text_field :name, class: 'form-control' %> 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -9,6 +9,7 @@
         <% end %> 
       </div>
     </div>
+    <%= render 'shared/error_messages', model: @reservation unless @reservation.nil? %>
     <div class="images-box">
       <div class="image-box"></div>
     </div>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -1,4 +1,3 @@
-<%= render 'shared/error_messages' %>
 <h1>ご予約内容確認</h1>
 <div class="detail-section">
   <div class="wrapper">

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,12 +1,9 @@
-<% if @event.errors.any? %>
-  <div id="error_explanation">
-    <div class="alert alert-danger">
-      The form contains <%= pluralize(@event.errors.count, 'error') %>.
-    </div>
+<% if model.errors.any? %>
+  <div class="alert alert-warning">
     <ul>
-    <% @event.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-    <% end %>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
     </ul>
   </div>
 <% end %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,7 +1,8 @@
 ja:
   activerecord:
     models:
-      event: イベント
+      event: ココロミ
+      hosted_date: 開催日時
     attributes:
       event:
         name: 名前
@@ -16,6 +17,10 @@ ja:
         ended_at: 終了日時
       reservation:
         comment: 連絡事項
+        hosted_date_id: 日時
+      hosted_dates:
+        started_at: 開始日時
+        ended_at: 終了日時
   devise:
     sessions:
       user:
@@ -27,4 +32,6 @@ ja:
   time:
     formats:
       short: "%H:%M"
-
+  errors:
+    messages:
+      taken: はすでに登録済みです


### PR DESCRIPTION
## やったこと
- errorsパーシャルを汎用化
  - パーシャルにインスタンスを渡す仕様にしてEvent以外のエラーメッセージを表示できるように変更
- バリデーション失敗時のバグを修正
  - Eventのcreate, updateでsave失敗時に@todayを取得することで、正常にフォームが表示されるようにした
  - Reservationのcreate時に/events/:idでエラーメッセージが表示されるように修正
- 日本語のエラー表示内容を追加
- フラッシュの表示内容を修正

## やっていないこと（今後実装予定）
- 特になし

## できるようになること（ユーザー目線）
- バリデーション失敗時にユーザーが取るべき行動が明確になる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- イベント新規作成・編集画面でバリデーション失敗時にエラーメッセージが表示されること
- 同じイベント・日時の組み合わせで予約しようとした際、イベント詳細ページでエラーメッセージが表示されること