### PR TITLE
ユーザー登録・ログイン周りの改善

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   # def new
@@ -38,18 +38,23 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super
   # end
 
-  # protected
+  protected
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nick_name, :phone_number, :profile])
+  end
 
-  # If you have extra params to permit, append them to the sanitizer.
-  # def configure_account_update_params
-  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
-  # end
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
 
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(:account_update, keys: [:nick_name, :phone_number, :profile])
+  end
+
+  def after_update_path_for(resource)
+    user_path(resource)
+  end
   # The path used after sign up.
   # def after_sign_up_path_for(resource)
   #   super(resource)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,5 @@
 module UsersHelper
+  def current_user?
+    @user.id == current_user.id
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
+  validates :profile, length: { maximum: 200 }
+
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,43 +1,49 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2>プロフィール変更</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+<%= form_with model: @user, url: user_registration_path, id: 'edit_user', class: 'edit_user', local: true do |f| %>
+  <%= render 'users/shared/error_messages' , resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  <div class="form-group">
+    <%= f.label :nick_name %>
+    <%= f.text_field :nick_name, class: 'form-control'%>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :profile %>
+    <%= f.text_area :profile, class: 'form-control'%>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control'%>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :phone_number %>
+    <%= f.phone_field :phone_number, autocomplete: 'tel', class: 'form-control'%>
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+  <div class="form-group">
+    <%= f.label :password %>
+    <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control'%>
     <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em><%= @minimum_password_length %>文字以上（変更しない場合はブランク）</em>
     <% end %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  <div class="form-group">
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control'%>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit 'プロフィールを変更する', class: 'btn btn-primary' %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
-<%= link_to "Back", :back %>
+<p><%= link_to '戻る', :back %></p>
+<p><%= link_to '退会する', registration_path(resource_name), data: { confirm: '本当に退会しますか?' }, method: :delete %></p>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,29 +1,44 @@
-<h2>Sign up</h2>
+<h2>新規ユーザー登録</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "users/shared/error_messages", resource: resource %>
+<%= form_with model: @user, url: user_registration_path, id: 'new_user', class: 'new_user', local: true do |f| %>
+  <%= render 'users/shared/error_messages', resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  <div class="form-group">
+    <%= f.label :nick_name %>
+    <%= f.text_field :nick_name, class: 'form-control'%>
   </div>
 
-  <div class="field">
+  <div class="form-group">
+    <%= f.label :profile %>
+    <%= f.text_area :profile, class: 'form-control'%>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :email %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :phone_number %>
+    <%= f.phone_field :phone_number, autocomplete: 'tel', class: 'form-control'%>
+  </div>
+
+  <div class="form-group">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
-    <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <em>(<%= @minimum_password_length %> 文字以上)</em>
+    <% end %>
+    <%= f.password_field :password, autocomplete: 'new-password', class: 'form-control' %>
   </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  <div class="form-group">
+    <%= f.label :password_confirmation %>
+    <%= f.password_field :password_confirmation, autocomplete: 'new-password', class: 'form-control' %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Sign up" %>
+    <%= f.submit '登録を完了する', class: 'btn btn-primary'%>
   </div>
 <% end %>
 
-<%= render "users/shared/links" %>
+<%= render 'users/shared/links' %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,26 @@
-<h2>Log in</h2>
+<h2>ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
+<%= form_with model: @user, url: user_session_path, id: 'new_user', class: 'new_user', local: true do |f| %>
+  <div class="form-group">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: 'email', class: 'form-control' %>
   </div>
 
-  <div class="field">
+  <div class="form-group">
     <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
+    <%= f.password_field :password, autocomplete: 'current-password', class: 'form-control' %>
   </div>
 
   <% if devise_mapping.rememberable? %>
-    <div class="field">
+    <div class="form-group">
       <%= f.check_box :remember_me %>
       <%= f.label :remember_me %>
     </div>
   <% end %>
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit 'ログインする', class: 'btn btn-primary' %>
   </div>
 <% end %>
 
-<%= render "users/shared/links" %>
+<%= render 'users/shared/links' %>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -1,13 +1,13 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to 'ログインする', new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to 'アカウントをお持ちでない方はこちら', new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to  'パスワードをお忘れの方はこちら', new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
@@ -20,6 +20,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= link_to "#{OmniAuth::Utils.camelize(provider)}でログインする", omniauth_authorize_path(resource_name, provider), method: :post %><br />
   <% end %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,6 +16,7 @@
       <% end %>
       <p class="user-name"><%= @user.nick_name %></p>
       <p class="user-profile"><%= @user.profile %> </p>
+      <%= link_to 'プロフィールを編集する', edit_user_registration_path, class: 'user-edit-link' if current_user? %>
     </div>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,7 +21,20 @@ ja:
       hosted_dates:
         started_at: 開始日時
         ended_at: 終了日時
+      user:
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認）
+        current_password: 現在のパスワード
+        nick_name: ニックネーム
+        profile: 自己紹介
+        phone_number: 電話番号
+        remember_me: ログインしたままにする
   devise:
+    registrations:
+      user:
+        signed_up: ユーザー登録しました
+        updated: ユーザー情報を更新しました
     sessions:
       user:
         signed_in: ログインしました
@@ -29,6 +42,9 @@ ja:
     omniauth_callbacks:
       user:
         success: ログインしました
+    failure:
+      user:
+        unauthenticated: ログインしてください
   time:
     formats:
       short: "%H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
   root 'home#index'
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
+  }
   resources :users, only: :show
 
   resources :events do


### PR DESCRIPTION
## やったこと
- 拡張できるように、registrationsとsessionsのルーティングを変更
- ユーザー登録時、編集時に登録できる属性を追加（ニックネーム、紹介文、電話番号）
- ヘルパーメソッドform_forをform_withへ変更
- 紹介文のバリデーションを最大200文字に設定
- ユーザー詳細ページにユーザー編集ページへのリンクを付与
- 関連フォーム、フラッシュメッセージの日本語化対応

## やっていないこと（今後実装予定）
- とくになし

## できるようになること（ユーザー目線）
- ユーザー登録時により多くの情報を登録できるようになる
- ユーザー情報を編集できるようになる


## できなくなること（ユーザ目線）
- とくになし

## 動作確認
- /users/edit内で変更した内容が反映されていること
- ユーザー詳細画面がログインユーザーの場合、ユーザー編集ページが表示されること