### PR TITLE
イベント予約管理機能を追加

### DIFF
--- a/app/assets/stylesheets/reservations.scss
+++ b/app/assets/stylesheets/reservations.scss
@@ -1,3 +1,52 @@
-// Place all the styles related to the reservations controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: https://sass-lang.com/
+.change-section {
+  background-color: #f5f5f5;
+  table  {
+    margin: 0 auto;
+    th, td{
+      padding-right: 20px;
+      border-bottom: dashed 1px black;
+      padding: 15px 15px 5px;
+    }
+    th {
+      font-weight: 500;
+      .detail-icon {
+        padding-top: 4px;
+        width: 15px;
+        text-align: right;
+        margin-right: 10px;
+      }
+    }
+  }
+}
+
+.detail-section {
+  .discription {
+    margin: 0 auto;
+    margin-bottom: 40px;
+    width: fit-content;
+    .detail-text {
+      line-height: 1.8;
+      table  {
+        td {
+          span.unit {
+            margin-left: 5px;
+            font-size: 1.3rem;
+            color: rgb(93, 91, 91);
+          }
+        }
+      }
+    }
+  }
+}
+
+.change-section {
+  .btn-area {
+    margin: 40px auto;
+    margin-bottom: 0;
+    max-width: 300px;
+    .btn-modest {
+      text-align: center;
+      margin: 20px;
+    }
+  }
+}

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -2,6 +2,10 @@ class ReservationsController < ApplicationController
   before_action :set_event_and_date, only: [:new, :create]
   permits :comment
   
+  def index
+    @reservations = current_user.reservations
+  end
+
   def new
     @reservation = current_user.reservations.build
   end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,5 +1,7 @@
 class ReservationsController < ApplicationController
-  before_action :set_event_and_date, only: [:new, :create]
+  before_action :set_event, only: [:new, :create]
+  before_action :set_date, only: [:new, :create]
+  before_action :set_reservation, only: [:show, :update, :destroy]
   permits :comment
   
   def index
@@ -17,18 +19,43 @@ class ReservationsController < ApplicationController
     end
     
     if @reservation.save
-      # TODO: 参加したココロミ一覧実装後は遷移先を変更する
-      redirect_to root_path, notice: 'ココロミを予約しました'
+      redirect_to user_reservations_path(current_user), notice: 'ココロミを予約しました'
     else
       flash.now[:error] = 'ココロミを予約できませんでした'
       render 'events/show'
     end
   end
 
+  def show
+    @event = Event.find(@reservation.event_id)
+    @date = HostedDate.find(@reservation.hosted_date_id)
+  end
+
+  def update(event_id:, date_id:)
+    if @reservation.update(event_id: event_id, hosted_date_id: date_id)
+      redirect_to user_reservations_path, notice: '予約を変更しました'
+    else
+      flash.now[:error] = '予約を変更できませんでした'
+      render 'show'
+    end
+  end
+
+  def destroy
+    @reservation.update(is_canceled: true)
+    redirect_to user_reservations_path, notice: '予約をキャンセルしました'
+  end
+
   private 
-  
-  def set_event_and_date(event_id:, date_id:)
+
+  def set_event(event_id:)
     @event = Event.find(event_id)
+  end
+
+  def set_date(date_id:)
     @date = HostedDate.find(date_id)
+  end
+
+  def set_reservation(id:)
+    @reservation = Reservation.find(id)
   end
 end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,5 +1,9 @@
 module ReservationsHelper
-  def format_created_date_by(date)
-    l(date.created_at, format: :default)
+  def format_updated_date_by(date)
+    l(date.updated_at, format: :default)
+  end
+
+  def date_options_by(event)
+    options_for_select(event.hosted_dates.map { |date| [format_date(date), date.id] })
   end
 end

--- a/app/helpers/reservations_helper.rb
+++ b/app/helpers/reservations_helper.rb
@@ -1,2 +1,5 @@
 module ReservationsHelper
+  def format_created_date_by(date)
+    l(date.created_at, format: :default)
+  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -9,4 +9,11 @@ class Reservation < ApplicationRecord
     validates :event_id
     validates :hosted_date_id, uniqueness: true 
   end
+
+  scope :with_associations, -> { preload(:hosted_date, :event) }
+  scope :reserved, -> { where(is_canceled: false) }
+  scope :canceled, -> { where(is_canceled: true) }
+  scope :sorted, -> { order(updated_at: :desc) }
+  scope :with_recent_associations, -> { with_associations.reserved.sorted }
+  scope :recent_canceled, -> { with_associations.canceled.sorted }
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -6,6 +6,7 @@
         <li><%= link_to 'ログイン', new_user_session_path %></li>
       <% else %>
         <li><%= link_to 'ココロミをつくる', new_event_path %></li>
+        <li><%= link_to '予約したココロミ', user_reservations_path(current_user) %></li>
         <li><%= link_to 'プロフィール', user_path(current_user) %></li>
         <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
       <% end %>

--- a/app/views/reservations/_canceled_event_item.html.erb
+++ b/app/views/reservations/_canceled_event_item.html.erb
@@ -1,0 +1,5 @@
+<%= link_to(event_path(id: reservation.event), class: 'list-group-item list-group-item-action') do %>
+  <h2 class="list-group-item-heading"><%= reservation.event.name %></h2>
+  <p class="mb-1"><%= reservation.event.title %></p>
+  <p>キャンセル日：<%= format_updated_date_by(reservation) %></p>
+<% end %>

--- a/app/views/reservations/_joined_event_item.html.erb
+++ b/app/views/reservations/_joined_event_item.html.erb
@@ -1,0 +1,5 @@
+<%= link_to(user_reservation_path(id: reservation), class: 'list-group-item list-group-item-action') do %>
+  <h2 class="list-group-item-heading"><%= reservation.event.name %> </h2>
+  <p class="mb-1"><%= reservation.event.title %> </p>
+  <p>予約日：<%= format_created_date_by(reservation) %> </p>
+<% end %>

--- a/app/views/reservations/_joined_event_item.html.erb
+++ b/app/views/reservations/_joined_event_item.html.erb
@@ -1,5 +1,6 @@
 <%= link_to(user_reservation_path(id: reservation), class: 'list-group-item list-group-item-action') do %>
-  <h2 class="list-group-item-heading"><%= reservation.event.name %> </h2>
-  <p class="mb-1"><%= reservation.event.title %> </p>
-  <p>予約日：<%= format_created_date_by(reservation) %> </p>
+  <h2 class="list-group-item-heading"><%= reservation.event.name %></h2>
+  <p class="mb-1"><%= reservation.event.title %></p>
+  <p>受付日：<%= format_created_date_by(reservation) %></p>
+  <p>予約日時：<%= format_date(reservation.hosted_date) %></p>
 <% end %>

--- a/app/views/reservations/_reserved_event_item.html.erb
+++ b/app/views/reservations/_reserved_event_item.html.erb
@@ -1,6 +1,6 @@
 <%= link_to(user_reservation_path(id: reservation), class: 'list-group-item list-group-item-action') do %>
   <h2 class="list-group-item-heading"><%= reservation.event.name %></h2>
   <p class="mb-1"><%= reservation.event.title %></p>
-  <p>受付日：<%= format_created_date_by(reservation) %></p>
+  <p>予約受付日：<%= format_updated_date_by(reservation) %></p>
   <p>予約日時：<%= format_date(reservation.hosted_date) %></p>
 <% end %>

--- a/app/views/reservations/canceled_index.html.erb
+++ b/app/views/reservations/canceled_index.html.erb
@@ -1,0 +1,5 @@
+<h1>キャンセルしたココロミ</h1>
+<%= link_to '予約済み一覧', user_reservations_path %> 
+<div class="list-group">
+  <%= render partial: 'canceled_event_item', collection: @reservations, as: 'reservation' %>
+</div>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -1,5 +1,5 @@
 <h1>予約したココロミ</h1>
-
+<%= render 'shared/error_messages', model: @reservation unless @reservation.nil? %>
 <div class="list-group">
   <%= render partial: 'joined_event_item', collection: @reservations, as: 'reservation' %>
 </div>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -1,0 +1,5 @@
+<h1>予約したココロミ</h1>
+
+<div class="list-group">
+  <%= render partial: 'joined_event_item', collection: @reservations, as: 'reservation' %>
+</div>

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -1,5 +1,5 @@
 <h1>予約したココロミ</h1>
-<%= render 'shared/error_messages', model: @reservation unless @reservation.nil? %>
+<%= link_to 'キャンセル済み一覧', user_canceled_reservations_path %> 
 <div class="list-group">
-  <%= render partial: 'joined_event_item', collection: @reservations, as: 'reservation' %>
+  <%= render partial: 'reserved_event_item', collection: @reservations, as: 'reservation' %>
 </div>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -1,0 +1,47 @@
+<div class="eye-catching">
+  <div class="wrapper">
+    <div class="event-header">
+      <h1><%= @event.name %> </h1>
+    </div>
+    <div class="images-box">
+      <div class="image-box"></div>
+    </div>
+    <div class="event-title">
+      <h2><%= @event.title %> </h2>
+    </div>
+  </div>
+</div>
+<div class="change-section">
+  <div class="wrapper">
+    <%= form_with model: @event, url: user_reservation_path(user_id: current_user, reservaiton_id: @reservation, event_id: @event, date_id: @date), method: :patch do |f| %> 
+      <table>
+        <tr>
+          <th><%= icon('fas', 'calendar-days', class: 'detail-icon')%>開催日時</th>
+          <td><%= f.select :id, options_for_select(@event.hosted_dates.map { |date| [format_date(date), date.id] }) %> </td>
+        </tr>
+        <tr>
+          <th><%= icon('fas', 'location-dot', class: 'detail-icon')%>場所</th>
+          <td><%= @event.place %></td>
+        </tr>
+        <!-- TODO: 参加人数と参加費計を算出できるようにする -->
+        <tr>
+          <th><%= icon('fas', 'users', class: 'detail-icon')%>参加人数</h3></th>
+          <td>1<span class="unit">人</span></td>
+        </tr>
+        <tr>
+          <th><%= icon('fas', 'yen-sign', class: 'detail-icon')%>参加費計</th>
+          <td><%= @event.price %><span class="unit">円</span></td>
+        </tr>
+        <!-- ここまで -->
+        <tr>
+        </tr>
+      </table>
+      <div class="btn-area">
+        <%= f.submit '予約内容を変更する', class: 'btn btn-default btn-block' %> 
+        <div class="btn-modest">
+          <%= link_to 'この予約をキャンセルする', user_reservation_path(user_id: current_user, reservaiton_id: @reservation), method: :delete, data: { confirm: '本当にキャンセルしますか？' } %> 
+        </div>
+      </div>
+    <% end %> 
+  </div>
+</div>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -3,6 +3,7 @@
     <div class="event-header">
       <h1><%= @event.name %> </h1>
     </div>
+    <%= render 'shared/error_messages', model: @reservation unless @reservation.nil? %>
     <div class="images-box">
       <div class="image-box"></div>
     </div>
@@ -13,11 +14,11 @@
 </div>
 <div class="change-section">
   <div class="wrapper">
-    <%= form_with model: @event, url: user_reservation_path(user_id: current_user, reservaiton_id: @reservation, event_id: @event, date_id: @date), method: :patch do |f| %> 
+    <%= form_with model: @reservation, url: user_reservation_path(user_id: current_user), method: :patch do |f| %> 
       <table>
         <tr>
           <th><%= icon('fas', 'calendar-days', class: 'detail-icon')%>開催日時</th>
-          <td><%= f.select :id, options_for_select(@event.hosted_dates.map { |date| [format_date(date), date.id] }) %> </td>
+          <td><%= f.select :hosted_date_id, date_options_by(@event) %> </td>
         </tr>
         <tr>
           <th><%= icon('fas', 'location-dot', class: 'detail-icon')%>場所</th>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -47,6 +47,7 @@ ja:
         unauthenticated: ログインしてください
   time:
     formats:
+      default: "%Y年%m月%d日"
       long: "%Y年%m月%d日(%a) %H:%M"
       short: "%H:%M"
   errors:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
   resources :users, only: :show do
+    get 'reservations/canceled', to: 'reservations#canceled_index', as: 'canceled_reservations'
     resources :reservations
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
     registrations: 'users/registrations',
     sessions: 'users/sessions'
   }
-  resources :users, only: :show
+  resources :users, only: :show do
+    resources :reservations
+  end
 
   resources :events do
     resources :reservations


### PR DESCRIPTION
## やったこと
- イベント予約管理機能追加
  - ユーザーに紐づく予約済みとキャンセル済みの一覧表示
  - イベント予約後は一覧画面に遷移するよう修正
  - 予約日時変更・キャンセル機能追加
- ヘルパーメソッド追加
  - 日時フォーマット整形ヘルパー
  - 日時セレクト作成ヘルパー 
- Reservationモデルに一覧取得用scopeを定義
- ナビゲーションバーに予約したイベント一覧リンク追加
- Reservation用テンプレートのCSS追加

## やっていないこと（今後実装予定）
- 参加人数・参加費の登録、変更機能
- オーナーがイベントに参加できてしまうバグを修正

## できるようになること（ユーザー目線）
- 予約・キャンセルしたイベントを確認することができる
- 予約内容を一部変更することができる

## できなくなること（ユーザ目線）
- 特になし

## 動作確認
- ナビゲーションメニューの「予約したココロミ」リンクを押下すると、予約済み一覧が表示されること
- 予約一覧のカードアイテムを押下すると予約内容の詳細ページに遷移し、以下の機能が使用できること
  - 予約日時の変更が成功した場合は予約一覧ページに戻り成功したフラッシュメッセージが表示されること
  - 既に予約した日時の場合は、変更に失敗して予約詳細ページ内で、フラッシュ、エラーメッセージが表示されること
  - キャンセルを押下するとモーダル確認画面が出て、実行することにより、キャンセル一覧画面に遷移すること
-  キャンセル一覧画面ではis_canceledがtrueの予約一覧が表示されていること
-  キャンセル一覧のカードアイテムを押下すると、イベント詳細ページに遷移すること

Closes #24 