### PR TITLE
予約状況などに応じて予約可否情報を表示

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,4 +23,12 @@ class Event < ApplicationRecord
     return false unless user
     owner.id == user.id
   end
+
+  def available?(date)
+    capacity_left_of(date) >= 1
+  end
+
+  def capacity_left_of(date)
+    self.capacity - self.reservations.where(hosted_date: date.id).reserved.count
+  end
 end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -5,9 +5,8 @@ class Reservation < ApplicationRecord
 
   validates :comment, length: { maximum: 200 }, allow_blank: true
   with_options presence: true do
-    validates :user_id
     validates :event_id
-    validates :hosted_date_id, uniqueness: true 
+    validates :hosted_date_id, uniqueness: { scope: [:user_id, :event_id] }
   end
 
   scope :with_associations, -> { preload(:hosted_date, :event) }

--- a/app/views/events/_hosted_date_show.html.erb
+++ b/app/views/events/_hosted_date_show.html.erb
@@ -3,12 +3,29 @@
     <%= icon('far', 'calendar-days', class: 'detail-icon')%>
     <%= format_date(date) %>
   </th>
-  <!-- TODO: 後で実装--------- -->
-  <td>
-    ◯<span class="rest-capacity">残り1人</span>
-  </td>
-  <td>
-    <%= link_to '予約する', new_event_reservation_path(event_id: date.event, date_id: date), class: "btn btn-default" %>
-  </td>
-  <!-- ---------------ここまで -->
+  <% if @event.created_by?(current_user) %>
+    <td>
+      <%= icon('far', 'circle', class: 'detail-icon') %>
+      <span class="rest-capacity">残り<%= @event.capacity_left_of(date) %> 人</span>
+    </td>
+    <td>
+      <%= link_to '予約する', '#', class: "btn btn-default disabled" %>
+    </td>
+  <% elsif @event.available?(date) %>
+    <td>
+      <%= icon('far', 'circle', class: 'detail-icon') %>
+      <span class="rest-capacity">残り<%= @event.capacity_left_of(date) %> 人</span>
+    </td>
+    <td>
+      <%= link_to '予約する', new_event_reservation_path(event_id: date.event, date_id: date), class: "btn btn-default" %>
+    </td>
+  <% else %>
+    <td>
+      <%= icon('fas', 'xmark', class: 'detail-icon') %>
+      <span class="rest-capacity">残り0 人</span>
+    </td>
+    <td>
+      <%= link_to '予約する', '#', class: "btn btn-default disabled" %>
+    </td>
+  <% end %>
 </tr>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -26,36 +26,20 @@
     </div>
     <table>
       <tr>
-        <th>
-          <%= icon('fas', 'yen-sign', class: 'detail-icon')%>価格
-        </th>
-        <td>
-          <%= @event.price %><span class="unit">円</span>
-        </td>
+        <th><%= icon('fas', 'yen-sign', class: 'detail-icon')%>価格</th>
+        <td><%= @event.price %><span class="unit">円</span></td>
       </tr>
       <tr>
-        <th>
-          <%= icon('fas', 'stopwatch', class: 'detail-icon')%>所要時間
-        </th>
-        <td>
-          <%= @event.required_time %><span class="unit">分</span>
-        </td>
+        <th><%= icon('fas', 'stopwatch', class: 'detail-icon')%>所要時間</th>
+        <td><%= @event.required_time %><span class="unit">分</span></td>
       </tr>
       <tr>
-        <th>
-          <%= icon('fas', 'users', class: 'detail-icon')%>定員</h3>
-        </th>
-        <td>
-          <%= @event.required_time %><span class="unit">人</span>
-        </td>
+        <th><%= icon('fas', 'users', class: 'detail-icon')%>定員</h3></th>
+        <td><%= @event.capacity %><span class="unit">人</span></td>
       </tr>
       <tr>
-        <th>
-          <%= icon('fas', 'location-dot', class: 'detail-icon')%>場所
-        </th>
-        <td>
-            <%= @event.place %>
-        </td>
+        <th><%= icon('fas', 'location-dot', class: 'detail-icon')%>場所</th>
+        <td><%= @event.place %></td>
       </tr>
     </table>
   </div>


### PR DESCRIPTION
## やったこと
- イベント詳細画面の予約セクション内で、予約状況などに応じて表示内容を変更するよう、ビューを変更
- インスタンスメソッドを定義
  - 日時が予約可能か確認する`available?`メソッド
  - 予約可能人数を算出する`capacity_left_of`メソッド
- Reservationのバリデーションを変更
  - schema.rbに合わせてuser_idのpresenceを削除
  - user_id, event_id, hosted_idの組み合わせがユニークとなるよう制約を修正
- イベント詳細ページで定員を表示すべきところが所要時間を表示してしまっている誤記を修正 
- 冗長なためevents/show.html.erbのth・tdタグ内改行を削除

## やっていないこと
- 予約リンク以外でアクセスしてきたリクエストに対するバリデーション処理

## できるようになること（ユーザー目線）
- イベントの日時ごとに、残り予約可能人数を把握できるようになる

## できなくなること（ユーザ目線）
- 既に予約したイベント・日時の組み合わせに対して予約リンクを押下できなくなる
- オーナーが自らのイベントの予約リンクを押下できなくなる
 
## 動作確認
- イベントの日時ごとに、残り予約可能人数を把握できるようになること
- イベント詳細ページで登録した定員が正常に表示されていること
- ユーザーが既に予約したイベント・日時の組み合わせに対して予約リンクを押下できないこと
- オーナーが自らのイベント詳細ページを確認すると全ての予約リンクを押下できないこと

Closes #28
Closes #29
Closes #30 