### PR TITLE
resolve #34

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -73,7 +73,11 @@
     <h2 class="section-header">作家さん</h2>
     <div class="owner-detail">
       <%= link_to(user_path @event.owner, class: 'detail-link') do %>
-        <%= image_tag @event.owner.image, class: 'owner-image' %>
+        <% if @event.owner.image.present? %>
+          <%= image_tag @event.owner.image, class: 'owner-image' %>
+        <% else %>
+          <%= image_tag 'blank_user_image.png', class: 'owner-image' %>
+        <% end %>
         <p class="owner-name"><%= @event.owner.nickname %></p>
       <% end %>
     </div>


### PR DESCRIPTION
## やったこと
- イベント詳細ページにて、プロフィール画像登録のないユーザーはブランク画像が表示されるようif文を追加

## やっていないこと（今後実装予定）
- とくになし

## できるようになること（ユーザー目線）
- 画像登録のないユーザーが作成するイベントも詳細ページが正常に表示されるようになる

## できなくなること（ユーザ目線）
- とくになし

## 動作確認
- イベント詳細ページにて、画像登録のないユーザーはブランク画像が表示されること