### PR TITLE
オーナー向けの管理画面を追加

### DIFF
--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -1,0 +1,6 @@
+// Place all the styles related to the dashboards controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/
+.detail-section, .dates-section {
+  background-color: #fff;
+}

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,0 +1,14 @@
+class DashboardsController < ApplicationController
+  def reservation_index
+    @reservations = current_user.created_event_reservations
+  end
+
+  def event_reservations(event_id)
+    @event = Event.find(event_id)
+    @reservations = @event.reservations
+  end
+
+  def event_index
+    @events = current_user.created_events
+  end
+end

--- a/app/helpers/dashboards_helper.rb
+++ b/app/helpers/dashboards_helper.rb
@@ -1,0 +1,2 @@
+module DashboardsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,8 @@
 class User < ApplicationRecord
   has_many :created_events, class_name: 'Event', foreign_key: 'owner_id'
   has_many :reservations
+  has_many :created_event_reservations, through: :created_events, source: :reservations
+
   devise :database_authenticatable, :registerable,
   :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook]
   # Include default devise modules. Others available are:

--- a/app/views/dashboards/_event_item.html.erb
+++ b/app/views/dashboards/_event_item.html.erb
@@ -1,0 +1,15 @@
+<tr>
+  <th scope="row">
+    <%= link_to event_dashboard_reservations_path(event) do %>
+      <%= event.name %>
+    <% end %>
+  </th>
+  <td><%= event.price %></td>
+  <td><%= event.place %></td>
+  <td><%= event.reservations.reserved.count %> </td>
+  <% if event.is_published %>
+    <td>公開</td>
+  <% else %> 
+    <td>非公開</td>
+  <% end %> 
+</tr>

--- a/app/views/dashboards/_reserved_event_item.html.erb
+++ b/app/views/dashboards/_reserved_event_item.html.erb
@@ -1,0 +1,15 @@
+<tr>
+  <th scope="row">
+    <%= link_to event_dashboard_reservations_path(reservation.event) do %>
+      <%= reservation.event.name %>
+    <% end %>
+  </th>
+  <td><%= format_updated_date_by(reservation) %></td>
+  <td><%= format_date(reservation.hosted_date) %></td>
+  <td><%= reservation.user.name %></td>
+  <% if reservation.is_canceled %>
+    <td>キャンセル</td>
+  <% else %> 
+    <td>予約</td>
+  <% end %> 
+</tr>

--- a/app/views/dashboards/event_index.html.erb
+++ b/app/views/dashboards/event_index.html.erb
@@ -1,0 +1,19 @@
+<div class="reservation-section">
+  <div class="wrapper">
+    <h2 class="section-header">ココロミ一覧</h2>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">ココロミ名</th>
+          <th scope="col">金額</th>
+          <th scope="col">場所</th>
+          <th scope="col">総受付数</th>
+          <th scope="col">ステータス</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'event_item', collection: @events, as: 'event' %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboards/event_reservations.html.erb
+++ b/app/views/dashboards/event_reservations.html.erb
@@ -1,0 +1,73 @@
+<div class="eye-catching">
+  <div class="wrapper">
+    <div class="event-header">
+      <h1><%= @event.name %> </h1>
+      <div class="btn-space">
+        <% if @event.created_by?(current_user) %> 
+          <%= link_to '編集する', edit_event_path(@event), class: 'btn btn-default' %> 
+          <%= link_to '削除する', event_path(@event), class: 'btn btn-danger', method: :delete, data: { confirm: '本当に削除しますか？' } %> 
+        <% end %> 
+      </div>
+    </div>
+    <%= render 'shared/error_messages', model: @reservation unless @reservation.nil? %>
+    <div class="images-box">
+      <div class="image-box"></div>
+    </div>
+    <div class="event-title">
+      <h2><%= @event.title %> </h2>
+    </div>
+  </div>
+</div>
+<div class="detail-section">
+  <div class="wrapper">
+    <h2 class="section-header">このココロミについて</h2>
+    <div class="discription">
+      <p class="detail-text"><%=safe_join(@event.discription.split("\n"),tag(:br))%></p>
+    </div>
+    <table>
+      <tr>
+        <th><%= icon('fas', 'yen-sign', class: 'detail-icon')%>価格</th>
+        <td><%= @event.price %><span class="unit">円</span></td>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'stopwatch', class: 'detail-icon')%>所要時間</th>
+        <td><%= @event.required_time %><span class="unit">分</span></td>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'users', class: 'detail-icon')%>定員</h3></th>
+        <td><%= @event.capacity %><span class="unit">人</span></td>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'location-dot', class: 'detail-icon')%>場所</th>
+        <td><%= @event.place %></td>
+      </tr>
+      <tr>
+        <th><%= icon('fas', 'earth-asia', class: 'detail-icon')%>ステータス</th>
+        <% if @event.is_published? %> 
+          <td>公開</td>
+        <% else %> 
+          <td>非公開</td>
+        <% end %> 
+      </tr>
+    </table>
+  </div>
+</div>
+<div class="reservation-section">
+  <div class="wrapper">
+    <h2 class="section-header">このココロミの予約一覧</h2>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">ココロミ</th>
+          <th scope="col">受付日</th>
+          <th scope="col">予約日時</th>
+          <th scope="col">名前</th>
+          <th scope="col">ステータス</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'reserved_event_item', collection: @reservations, as: 'reservation' %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboards/reservation_index.html.erb
+++ b/app/views/dashboards/reservation_index.html.erb
@@ -1,0 +1,15 @@
+<h1>つくったココロミの予約一覧</h1>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">ココロミ</th>
+      <th scope="col">受付日</th>
+      <th scope="col">予約日時</th>
+      <th scope="col">名前</th>
+      <th scope="col">ステータス</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: 'reserved_event_item', collection: @reservations, as: 'reservation' %>
+  </tbody>
+</table>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,6 +7,8 @@
       <% else %>
         <li><%= link_to 'ココロミをつくる', new_event_path %></li>
         <li><%= link_to '予約したココロミ', user_reservations_path(current_user) %></li>
+        <li><%= link_to 'つくったココロミの予約一覧', user_dashboard_reservations_path(current_user) %></li>
+        <li><%= link_to 'つくったココロミ一覧', user_dashboard_events_path(current_user) %></li>
         <li><%= link_to 'プロフィール', user_path(current_user) %></li>
         <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,11 +6,15 @@ Rails.application.routes.draw do
     sessions: 'users/sessions'
   }
   resources :users, only: :show do
+    resources :reservations, only: [:index, :show, :update, :destroy]
     get 'reservations/canceled', to: 'reservations#canceled_index', as: 'canceled_reservations'
-    resources :reservations
+    get 'dashboards/reservations', to: 'dashboards#reservation_index', as: 'dashboard_reservations'
+    get 'dashboards/events', to: 'dashboards#event_index', as: 'dashboard_events'
   end
 
   resources :events do
-    resources :reservations
+    resources :reservations, only: [:new, :create]
+    get 'reservations', to: 'dashboards#event_reservations', as: 'dashboard_reservations'
   end
+
 end

--- a/test/controllers/dashboards_controller_test.rb
+++ b/test/controllers/dashboards_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DashboardsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## やったこと
- オーナーが作ったイベントの予約一覧が取得できるようhas_manyメソッドを追加
- Dashboardコントローラを作成し、関連するビューとルーティングを追加
  - オーナーが作ったイベントの予約一覧を表示
  - オーナーが作ったイベントの一覧を表示
  - オーナーが作ったイベントとイベントに紐づく予約一覧を表示
- ナビゲーションヘッダーに関連リンクを設置 

## やっていないこと（今後実装予定）
- 顧客一覧表示
- オーナーでないユーザーが（イベントを作成していない場合）管理画面にアクセスした際その旨を知らせること

## できるようになること（オーナー目線）
- 作ったイベントの予約状況を表で確認できるようになる
- 作ったイベントを表で確認できるようになる
- 作ったイベントと紐づく予約状況を表で確認できるようになる

## できなくなること（ユーザ目線）
- とくになし

## 動作確認
- 「つくったココロミ一覧」でオーナーが作ったイベント情報（ココロミ名 | 金額 | 場所 | 総受付数 | ステータス）が一覧で確認できること
- /users/:id/dashboards/reservationsでオーナーが作ったイベントの予約情報（ココロミ | 受付日 | 予約日時 | 名前 | ステータス）が一覧で確認できること
- 上記一覧内のイベント名をクリックすると/events/:id/reservationsへ遷移し、イベント内容（公開ステータス）とその予約情報（ココロミ | 受付日 | 予約日時 | 名前 | ステータス）が一覧で確認できること

close #32 
close #37 

