### PR TITLE
管理画面で顧客情報を表示

### DIFF
--- a/app/assets/stylesheets/dashboards.scss
+++ b/app/assets/stylesheets/dashboards.scss
@@ -3,4 +3,23 @@
 // You can use Sass (SCSS) here: https://sass-lang.com/
 .detail-section, .dates-section {
   background-color: #fff;
+  .section-header {
+    margin-bottom: 30px;
+  }
+  text-align: center;
+  .user-image {
+    width: 75px;
+    height: 75px;
+    border-radius: 50%;
+    margin-bottom: 10px;
+  }
+}
+
+.customer-section {
+  margin: 0 auto;
+  text-align: center;
+  margin-bottom: 40px;
+  .detail-link {
+    display: block;
+  }
 }

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -11,4 +11,13 @@ class DashboardsController < ApplicationController
   def event_index
     @events = current_user.created_events
   end
+
+  def customer_index
+    @customers = current_user.customers
+  end
+
+  def customer_reservations(id)
+    @customer = User.find(id)
+    @reservations = current_user.reservations_by_customer(id)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_many :created_events, class_name: 'Event', foreign_key: 'owner_id'
   has_many :reservations
   has_many :created_event_reservations, through: :created_events, source: :reservations
+  has_many :customers, -> { distinct }, through: :created_event_reservations, source: :user
 
   devise :database_authenticatable, :registerable,
   :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook]
@@ -9,6 +10,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
 
   validates :profile, length: { maximum: 200 }
+
+  def reservations_by_customer(id)
+    created_event_reservations.where(user_id: id)
+  end
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/dashboards/_customer_item.html.erb
+++ b/app/views/dashboards/_customer_item.html.erb
@@ -1,0 +1,10 @@
+<tr>
+  <th scope="row">
+    <%= link_to customer_reservations_path(customer) do %>
+      <%= customer.nickname %>
+    <% end %> 
+  </th>
+  <td><%= customer.name %></td>
+  <td><%= customer.phone_number %></td>
+  <td><%= customer.email %></td>
+</tr>

--- a/app/views/dashboards/_event_item.html.erb
+++ b/app/views/dashboards/_event_item.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <th scope="row">
-    <%= link_to event_dashboard_reservations_path(event) do %>
+    <%= link_to event_reservations_path(event) do %>
       <%= event.name %>
     <% end %>
   </th>

--- a/app/views/dashboards/_reservaiton_item.html.erb
+++ b/app/views/dashboards/_reservaiton_item.html.erb
@@ -6,7 +6,6 @@
   </th>
   <td><%= format_updated_date_by(reservation) %></td>
   <td><%= format_date(reservation.hosted_date) %></td>
-  <td><%= reservation.user.name %></td>
   <% if reservation.is_canceled %>
     <td>キャンセル</td>
   <% else %> 

--- a/app/views/dashboards/customer_index.html.erb
+++ b/app/views/dashboards/customer_index.html.erb
@@ -1,0 +1,18 @@
+<div class="customer-section">
+  <div class="wrapper">
+    <h2 class="section-header">顧客一覧</h2>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">ニックネーム</th>
+          <th scope="col">名前</th>
+          <th scope="col">電話番号</th>
+          <th scope="col">email</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'customer_item', collection: @customers, as: 'customer' %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/dashboards/customer_reservations.html.erb
+++ b/app/views/dashboards/customer_reservations.html.erb
@@ -1,0 +1,52 @@
+<div class="detail-section">
+  <div class="wrapper">
+    <h2 class="section-header">顧客情報詳細</h2>
+    <%= link_to(user_path @customer, class: 'detail-link') do %>
+        <% if @customer.image.present? %>
+          <%= image_tag @customer.image, class: 'user-image' %>
+        <% else %>
+          <%= image_tag 'blank_user_image.png', class: 'user-image' %>
+        <% end %>
+    <% end %>
+    <table>
+      <tr>
+        <th>名前</th>
+        <td><%= @customer.name %></td>
+      </tr>
+      <tr>
+        <th>ニックネーム</th>
+        <td><%= @customer.nickname %></td>
+      </tr>
+      <tr>
+        <th>電話番号</th>
+        <td><%= @customer.phone_number %></td>
+      </tr>
+      <tr>
+        <th>メールアドレス</th>
+        <td><%= @customer.email %></td>
+      </tr>
+      <tr>
+        <th>お客さまメモ</th>
+        <td></td>
+      </tr>
+    </table>
+  </div>
+</div>
+<div class="reservation-section">
+  <div class="wrapper">
+    <h2 class="section-header">顧客の予約一覧</h2>
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">ココロミ</th>
+          <th scope="col">受付日</th>
+          <th scope="col">予約日時</th>
+          <th scope="col">ステータス</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: 'reservaiton_item', collection: @reservations, as: 'reservation' %>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,8 +7,9 @@
       <% else %>
         <li><%= link_to 'ココロミをつくる', new_event_path %></li>
         <li><%= link_to '予約したココロミ', user_reservations_path(current_user) %></li>
-        <li><%= link_to 'つくったココロミの予約一覧', user_dashboard_reservations_path(current_user) %></li>
-        <li><%= link_to 'つくったココロミ一覧', user_dashboard_events_path(current_user) %></li>
+        <li><%= link_to 'つくったココロミの予約一覧', dashboard_reservations_path %></li>
+        <li><%= link_to 'つくったココロミ一覧', dashboard_events_path %></li>
+        <li><%= link_to '顧客一覧', dashboard_customers_path %></li>
         <li><%= link_to 'プロフィール', user_path(current_user) %></li>
         <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,26 @@
 Rails.application.routes.draw do
   root 'home#index'
+
   devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks',
     registrations: 'users/registrations',
     sessions: 'users/sessions'
   }
+
   resources :users, only: :show do
     resources :reservations, only: [:index, :show, :update, :destroy]
     get 'reservations/canceled', to: 'reservations#canceled_index', as: 'canceled_reservations'
-    get 'dashboards/reservations', to: 'dashboards#reservation_index', as: 'dashboard_reservations'
-    get 'dashboards/events', to: 'dashboards#event_index', as: 'dashboard_events'
   end
 
   resources :events do
     resources :reservations, only: [:new, :create]
-    get 'reservations', to: 'dashboards#event_reservations', as: 'dashboard_reservations'
+    get 'reservations', to: 'dashboards#event_reservations'
   end
 
+  scope '/dashboard' do
+    get 'reservations', to: 'dashboards#reservation_index', as: 'dashboard_reservations'
+    get 'events', to: 'dashboards#event_index', as: 'dashboard_events'
+    get 'customers', to: 'dashboards#customer_index', as: 'dashboard_customers'
+    get 'customers/:id', to: 'dashboards#customer_reservations', as: 'customer_reservations'
+  end
 end


### PR DESCRIPTION
## やったこと
- cssを追加
- 顧客一覧を表示
  - オーナーが作成したイベントに紐づくユーザーを取得するcustomersメソッドを定義 
  - 顧客情報を表示するビュー（表）を作成
- 顧客と予約一覧を表示
  - 顧客ごとの予約一覧を取得するreservations_by_customerメソッドを定義
  - 予約情報を表示するビュー（表）を作成
- 多段ネストしたdashboadルーティングを修正して、関連する参照パスを修正

## やっていないこと（今後実装予定）
- 識別のため、予約番号を発行して、予約一覧に表示させる
- 顧客メモ登録・編集機能

## できるようになること（オーナー目線）
- これまで予約してくれたユーザーを顧客一覧として確認できる
- 顧客ごとの予約情報を閲覧することで嗜好が把握できる。

## できなくなること（ユーザ目線）
- とくになし

## 動作確認
1. トップページ
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/87155363/206450767-b0518ea0-c7ed-4898-b8e4-8c254f16a8a3.png">
2. ナビゲーションバーの顧客一覧リンク（/dashboard/customers)を押下すると、作成したイベントを予約したことがあるユーザー一覧が確認できること
<img width="1424" alt="image" src="https://user-images.githubusercontent.com/87155363/206454418-4bdc2162-a2bd-4845-b4d1-7bd32c8eae26.png">
3. 上記1のユーザーニックネームリンク（/dashboard/customers/:id)を押下すると、顧客情報とオーナー作成のイベントに紐づくユーザーの予約一覧が確認できること
<img width="718" alt="image" src="https://user-images.githubusercontent.com/87155363/206454526-3cc3d0fd-42ff-4c5b-9e10-6cc838be21e3.png">
4. 上記2のココロミ名リンク（/events/:id/reservations）を押下すると、イベント情報とそれに紐づく予約情報が確認できること
<img width="625" alt="image" src="https://user-images.githubusercontent.com/87155363/206454670-ae1300f9-4a7e-4e2d-a020-2984d1179060.png">
