### PR TITLE
ユーザー退会プロセスを改善

### DIFF
--- a/app/assets/stylesheets/retirements.scss
+++ b/app/assets/stylesheets/retirements.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the retirements controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -16,8 +16,8 @@ class DashboardsController < ApplicationController
     @customers = current_user.customers
   end
 
-  def customer_reservations(id)
-    @customer = User.find(id)
-    @reservations = current_user.reservations_by_customer(id)
+  def customer_reservations(customer_id)
+    @customer = User.find(customer_id)
+    @reservations = current_user.reservations_by(@customer)
   end
 end

--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -1,0 +1,14 @@
+class RetirementsController < ApplicationController
+  def new
+  end
+
+  def create
+    if current_user.destroy
+      reset_session
+      redirect_to root_path, notice: '退会完了しました'
+    else
+      flash.now[:error] = '退会することができませんでした'
+      render :new
+    end
+  end
+end

--- a/app/helpers/retirements_helper.rb
+++ b/app/helpers/retirements_helper.rb
@@ -1,0 +1,2 @@
+module RetirementsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,7 @@ class Event < ApplicationRecord
   scope :recent, -> { published.sorted }
 
   def created_by?(user)
-    return false unless user
+    return false unless user && owner
     owner.id == user.id
   end
 end

--- a/app/views/dashboards/_reserved_event_item.html.erb
+++ b/app/views/dashboards/_reserved_event_item.html.erb
@@ -6,7 +6,11 @@
   </th>
   <td><%= format_updated_date_by(reservation) %></td>
   <td><%= format_date(reservation.hosted_date) %></td>
-  <td><%= reservation.user.name %></td>
+  <% if reservation.user.present?%> 
+    <td><%= reservation.user.name %></td>
+  <% else %> 
+    <td>退会したユーザー</td>
+  <% end %> 
   <% if reservation.is_canceled %>
     <td>キャンセル</td>
   <% else %> 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -44,26 +44,32 @@
     </table>
   </div>
 </div>
-<div class="dates-section">
-  <div class="wrapper">
-    <h2 class="section-header">開催日から予約</h2>
-    <table>
-      <%= render partial: 'events/hosted_date_show', collection: @event.hosted_dates, as: 'date' %>
-    </table>
-  </div>
-</div>
-<div class="owner-section">
-  <div class="wrapper">
-    <h2 class="section-header">作家さん</h2>
-    <div class="owner-detail">
-      <%= link_to(user_path @event.owner, class: 'detail-link') do %>
-        <% if @event.owner.image.present? %>
-          <%= image_tag @event.owner.image, class: 'owner-image' %>
-        <% else %>
-          <%= image_tag 'blank_user_image.png', class: 'owner-image' %>
-        <% end %>
-        <p class="owner-name"><%= @event.owner.nickname %></p>
-      <% end %>
+<% if @event.owner.present? %> 
+  <div class="dates-section">
+    <div class="wrapper">
+      <h2 class="section-header">開催日から予約</h2>
+      <table>
+        <%= render partial: 'events/hosted_date_show', collection: @event.hosted_dates, as: 'date' %>
+      </table>
     </div>
   </div>
-</div>
+  <div class="owner-section">
+    <div class="wrapper">
+      <h2 class="section-header">作家さん</h2>
+      <div class="owner-detail">
+        <%= link_to(user_path @event.owner, class: 'detail-link') do %>
+          <% if @event.owner.image.present? %>
+            <%= image_tag @event.owner.image, class: 'owner-image' %>
+          <% else %>
+            <%= image_tag 'blank_user_image.png', class: 'owner-image' %>
+          <% end %>
+          <p class="owner-name"><%= @event.owner.nickname %></p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% else %> 
+  <div class="wrapper">
+    <p>オーナーが退会したため、予約することができません。</p>
+  </div>
+<% end %> 

--- a/app/views/retirements/new.html.erb
+++ b/app/views/retirements/new.html.erb
@@ -1,0 +1,14 @@
+<div class="retirement-section">
+  <div class="wrapper">
+    <h1>退会の確認</h1>
+    <%= render 'shared/error_messages', model: current_user %>
+    <p>退会した場合、ユーザーに関するデータがすべて削除されます</p>
+    <p>ただし、以下の場合は退会できません</p>
+    <ul>
+      <li>公開中の未終了ココロミがある場合</li>
+      <li>未終了の参加ココロミがある場合</li>
+    </ul>
+    <hr>
+    <%= link_to '退会する', retirements_path, method: :post, class: 'btn btn-danger', data: { confirm: '本当に退会しますか？' } %> 
+  </div>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -46,4 +46,4 @@
 <% end %>
 
 <p><%= link_to '戻る', :back %></p>
-<p><%= link_to '退会する', registration_path(resource_name), data: { confirm: '本当に退会しますか?' }, method: :delete %></p>
+<p><%= link_to '退会する', new_retirements_path %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     get 'reservations', to: 'dashboards#reservation_index', as: 'dashboard_reservations'
     get 'events', to: 'dashboards#event_index', as: 'dashboard_events'
     get 'customers', to: 'dashboards#customer_index', as: 'dashboard_customers'
-    get 'customers/:id', to: 'dashboards#customer_reservations', as: 'customer_reservations'
+    get 'customers/:customer_id', to: 'dashboards#customer_reservations', as: 'customer_reservations'
   end
 
   resource :retirements, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,4 +23,6 @@ Rails.application.routes.draw do
     get 'customers', to: 'dashboards#customer_index', as: 'dashboard_customers'
     get 'customers/:id', to: 'dashboards#customer_reservations', as: 'customer_reservations'
   end
+
+  resource :retirements, only: [:new, :create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
   }
 
   resources :users, only: :show do
-    resources :reservations, only: [:index, :show, :update, :destroy]
     get 'reservations/canceled', to: 'reservations#canceled_index', as: 'canceled_reservations'
+    resources :reservations, only: [:index, :show, :update, :destroy]
   end
 
   resources :events do

--- a/test/controllers/retirements_controller_test.rb
+++ b/test/controllers/retirements_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RetirementsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## やったこと
- Retirementsコントローラとビューを作成し手続きを退会手続きを集約
- has_many :created_events, :reservationsにnullifyを追記しowner_id無しのイベント情報と予約情報表示に対応
- user削除前のコールバックメソッドcheck_all_events_finishedを追加し、以下の関連メソッドを追加
  - has_many :created_event_hosted_dates
  - has_many :participating_events
  - has_many :participating_event_hosted_dates
- ユーザー情報を参照するビューを修正し、退会したユーザーが分かるよう表示
  - つくったココロミの予約一覧画面
  - イベント詳細画面
- Eventのcreated_by?インスタンスメソッドを、退会したowner用に改修
- キャンセル済み一覧画面（/users/:user_id/reservations/canceled）にアクセスしたらshowアクションが反応するバグを修正するためルーティングを変更

## やっていないこと（今後実装予定）
- とくに無し

## できるようになること
- 条件に合う時のみ退会できるようになり、EventやReservation関連の整合性が保たれる
- 退会したユーザーも予約履歴に残るようになり、総予約数などの集計は引き続きできるようになる（ユーザー目線）

## できなくなること（ユーザ目線）
- 作成済み、参加済みの未開催イベントが存在するときは退会できなくなる

## 動作確認
- [x] 「退会」をクリックしたら退会確認画面に遷移する
- [x] 条件を満たさない場合はエラーメッセージが表示される
- [x] 作成済み、参加済みの未開催イベントが存在するときは退会できない
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/87155363/206935471-29595d47-4eb4-4e2c-979e-76878c893a49.png">

- [x] 退会確認画面で、条件を満たしつつ「退会する」をクリックすると退会できる
- [x] 退会した時、ユーザーレコードは削除
- [x] 退会した時、ユーザー作成イベントのowner_idをnullにする
- [x] 退会した時、ユーザー参加イベントReservationのuser_idはnullにする
<img width="931" alt="image" src="https://user-images.githubusercontent.com/87155363/206936108-6ffaf167-676a-46a6-8b72-2846a595deea.png">

- [x] 退会したユーザーが参照される場合はその旨表示する

イベント詳細画面(/events/:id)
<img width="717" alt="image" src="https://user-images.githubusercontent.com/87155363/207040385-975af6b0-8c4f-4a2c-90c8-9c32e083b123.png">

作成したイベントごとの予約者一覧画面(/events/:id/reservations)
<img width="754" alt="image" src="https://user-images.githubusercontent.com/87155363/207039753-0d8fb560-2cef-4c03-98b7-426886f97b39.png">