### PR TITLE
論理削除によるユーザー退会プロセスの導入と適用

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,3 +71,4 @@ gem 'net-imap', require: false
 gem 'net-pop', require: false
 
 gem 'action_args'
+gem 'discard', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    discard (1.2.1)
+      activerecord (>= 4.2, < 8)
     erubi (1.11.0)
     execjs (2.8.1)
     faraday (2.6.0)
@@ -290,6 +292,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   cocoon
   devise
+  discard (~> 1.2)
   font-awesome-sass (~> 6.2.0)
   hirb
   hirb-unicode

--- a/app/assets/stylesheets/retirements.scss
+++ b/app/assets/stylesheets/retirements.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the retirements controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -16,8 +16,8 @@ class DashboardsController < ApplicationController
     @customers = current_user.customers
   end
 
-  def customer_reservations(id)
-    @customer = User.find(id)
-    @reservations = current_user.reservations_by_customer(id)
+  def customer_reservations(customer_id)
+    @customer = User.find(customer_id)
+    @reservations = current_user.reservations_by(@customer)
   end
 end

--- a/app/controllers/retirements_controller.rb
+++ b/app/controllers/retirements_controller.rb
@@ -1,0 +1,14 @@
+class RetirementsController < ApplicationController
+  def new
+  end
+
+  def create
+    if current_user.mask_and_discard
+      reset_session
+      redirect_to root_path, notice: '退会完了しました'
+    else
+      flash.now[:error] = '退会することができませんでした'
+      render :new
+    end
+  end
+end

--- a/app/helpers/retirements_helper.rb
+++ b/app/helpers/retirements_helper.rb
@@ -1,0 +1,2 @@
+module RetirementsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -14,7 +14,7 @@ class Event < ApplicationRecord
   validates :is_published, inclusion: {in: [true, false]}
 
   scope :with_dates, -> { eager_load(:hosted_dates) }
-  scope :published, -> { where(is_published: true) }
+  scope :published, -> { joins(:owner).merge(User.kept).where(is_published: true) }
   scope :sorted, -> { order(updated_at: :desc) }
   scope :with_recent_dates, -> { with_dates.published.sorted }
   scope :recent, -> { published.sorted }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include Discard::Model
   has_many :created_events, class_name: 'Event', foreign_key: 'owner_id'
   has_many :reservations
   has_many :created_event_reservations, through: :created_events, source: :reservations
@@ -13,6 +14,10 @@ class User < ApplicationRecord
 
   def reservations_by_customer(id)
     created_event_reservations.where(user_id: id)
+  end
+
+  def active_for_authentication?
+    super && kept?
   end
 
   def self.from_omniauth(auth)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,8 @@
 class User < ApplicationRecord
   include Discard::Model
+
   has_many :created_events, class_name: 'Event', foreign_key: 'owner_id'
   has_many :reservations
-  has_many :created_event_reservations, through: :created_events, source: :reservations
-  has_many :customers, -> { distinct }, through: :created_event_reservations, source: :user
 
   devise :database_authenticatable, :registerable,
   :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: %i[facebook]
@@ -12,14 +11,27 @@ class User < ApplicationRecord
 
   validates :profile, length: { maximum: 200 }
 
-  def reservations_by_customer(id)
-    created_event_reservations.where(user_id: id)
+  def created_event_reservations
+    Reservation.joins(:event).where(event: { owner_id: self })
   end
 
-  def active_for_authentication?
-    super && kept?
+  def customers
+    User.kept.joins(reservations: :event).where(events: { owner_id: self }).distinct
   end
-
+  
+  def reservations_by(customer)
+    created_event_reservations.where(user_id: customer)
+  end
+  
+  def mask_and_discard
+    return false unless check_all_events_finished 
+    
+    ActiveRecord::Base.transaction do
+      mask_personal_data!
+      discard!
+    end
+  end
+  
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email
@@ -30,5 +42,38 @@ class User < ApplicationRecord
       # uncomment the line below to skip the confirmation emails.
       # user.skip_confirmation!
     end
+  end
+  
+  private
+  
+  def check_all_events_finished
+    now = Time.zone.now
+    if created_event_hosted_dates.where(':now < ended_at', now: now).exists?
+      errors.add(:base, '公開中の未終了イベントが存在します')
+    end
+    
+    if participating_event_hosted_dates.where(':now < ended_at', now: now).exists?
+      errors.add(:base, '未終了の参加イベントが存在します')
+    end
+    
+    errors.empty?
+  end
+
+  def created_event_hosted_dates
+    HostedDate.joins(:event).where(events: { owner_id: self, is_published: true })
+  end
+
+  def participating_event_hosted_dates
+    HostedDate.joins(reservations: :event).where(reservations: { user_id: self, is_canceled: false })
+  end
+  
+  def mask_personal_data!
+    self.update!(
+      email: "#{SecureRandom.urlsafe_base64}@example.com",
+      phone_number: nil,
+      uid: nil,
+      name: nil,
+      image: nil,
+    )
   end
 end

--- a/app/views/dashboards/_reserved_event_item.html.erb
+++ b/app/views/dashboards/_reserved_event_item.html.erb
@@ -6,7 +6,11 @@
   </th>
   <td><%= format_updated_date_by(reservation) %></td>
   <td><%= format_date(reservation.hosted_date) %></td>
-  <td><%= reservation.user.name %></td>
+  <% if reservation.user.kept?%> 
+    <td><%= reservation.user.name %></td>
+  <% else %> 
+    <td>退会したユーザー</td>
+  <% end %> 
   <% if reservation.is_canceled %>
     <td>キャンセル</td>
   <% else %> 

--- a/app/views/reservations/_canceled_event_detail.html.erb
+++ b/app/views/reservations/_canceled_event_detail.html.erb
@@ -1,0 +1,3 @@
+<h2 class="list-group-item-heading"><%= reservation.event.name %></h2>
+<p class="mb-1"><%= reservation.event.title %></p>
+<p>キャンセル日：<%= format_updated_date_by(reservation) %></p>

--- a/app/views/reservations/_canceled_event_item.html.erb
+++ b/app/views/reservations/_canceled_event_item.html.erb
@@ -1,5 +1,10 @@
-<%= link_to(event_path(id: reservation.event), class: 'list-group-item list-group-item-action') do %>
-  <h2 class="list-group-item-heading"><%= reservation.event.name %></h2>
-  <p class="mb-1"><%= reservation.event.title %></p>
-  <p>キャンセル日：<%= format_updated_date_by(reservation) %></p>
-<% end %>
+<% if reservation.event.owner.kept? %> 
+  <%= link_to(user_reservation_path(id: reservation), class: 'list-group-item list-group-item-action') do %>
+    <%= render 'canceled_event_detail', reservation: reservation %> 
+  <% end %>
+<% else %> 
+  <div class="list-group-item list-group-item-action">
+    <p class="text-danger">退会したユーザーのココロミです。</p>
+    <%= render 'canceled_event_detail', reservation: reservation %> 
+  </div>
+<% end %> 

--- a/app/views/reservations/_reserved_event_detail.html.erb
+++ b/app/views/reservations/_reserved_event_detail.html.erb
@@ -1,0 +1,4 @@
+<h2 class="list-group-item-heading"><%= reservation.event.name %></h2>
+<p class="mb-1"><%= reservation.event.title %></p>
+<p>予約受付日：<%= format_updated_date_by(reservation) %></p>
+<p>予約日時：<%= format_date(reservation.hosted_date) %></p>

--- a/app/views/reservations/_reserved_event_item.html.erb
+++ b/app/views/reservations/_reserved_event_item.html.erb
@@ -1,6 +1,10 @@
-<%= link_to(user_reservation_path(id: reservation), class: 'list-group-item list-group-item-action') do %>
-  <h2 class="list-group-item-heading"><%= reservation.event.name %></h2>
-  <p class="mb-1"><%= reservation.event.title %></p>
-  <p>予約受付日：<%= format_updated_date_by(reservation) %></p>
-  <p>予約日時：<%= format_date(reservation.hosted_date) %></p>
-<% end %>
+<% if reservation.event.owner.kept? %> 
+  <%= link_to(user_reservation_path(id: reservation), class: 'list-group-item list-group-item-action') do %>
+    <%= render 'reserved_event_detail', reservation: reservation %> 
+  <% end %>
+<% else %> 
+  <div class="list-group-item list-group-item-action">
+    <p class="text-danger">退会したユーザーのココロミです。</p>
+    <%= render 'reserved_event_detail', reservation: reservation %> 
+  </div>
+<% end %> 

--- a/app/views/retirements/new.html.erb
+++ b/app/views/retirements/new.html.erb
@@ -1,0 +1,14 @@
+<div class="retirement-section">
+  <div class="wrapper">
+    <h1>退会の確認</h1>
+    <%= render 'shared/error_messages', model: current_user %>
+    <p>退会した場合、ユーザーに関するデータがすべて削除されます</p>
+    <p>ただし、以下の場合は退会できません</p>
+    <ul>
+      <li>公開中の未終了ココロミがある場合</li>
+      <li>未終了の参加ココロミがある場合</li>
+    </ul>
+    <hr>
+    <%= link_to '退会する', retirements_path, method: :post, class: 'btn btn-danger', data: { confirm: '本当に退会しますか？' } %> 
+  </div>
+</div>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -46,4 +46,4 @@
 <% end %>
 
 <p><%= link_to '戻る', :back %></p>
-<p><%= link_to '退会する', registration_path(resource_name), data: { confirm: '本当に退会しますか?' }, method: :delete %></p>
+<p><%= link_to '退会する', new_retirements_path %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,22 +1,26 @@
-<div class="events-section">
-  <div class="wrapper">
-    <% if @events.any? %>
-      <h1><%= @user.nickname %>のココロミ</h1>
-      <%= render partial: 'events/event_item', collection: @events, as: 'event' %>
-    <% end %>
-  </div>
-</div>
-<div class="user-section">
-  <div class="wrapper">
-    <div class="user-detail">
-      <% if @user.image.present? %>
-        <%= image_tag @user.image, class: 'user-image' %>
-      <% else %>
-        <%= image_tag 'blank_user_image.png', class: 'user-image' %>
+<% if @user.kept? %> 
+  <div class="events-section">
+    <div class="wrapper">
+      <% if @events.any? %>
+        <h1><%= @user.nickname %>のココロミ</h1>
+        <%= render partial: 'events/event_item', collection: @events, as: 'event' %>
       <% end %>
-      <p class="user-name"><%= @user.nickname %></p>
-      <p class="user-profile"><%= @user.profile %> </p>
-      <%= link_to 'プロフィールを編集する', edit_user_registration_path, class: 'user-edit-link' if current_user? %>
     </div>
   </div>
-</div>
+  <div class="user-section">
+    <div class="wrapper">
+      <div class="user-detail">
+        <% if @user.image.present? %>
+          <%= image_tag @user.image, class: 'user-image' %>
+        <% else %>
+          <%= image_tag 'blank_user_image.png', class: 'user-image' %>
+        <% end %>
+        <p class="user-name"><%= @user.nickname %></p>
+        <p class="user-profile"><%= @user.profile %> </p>
+        <%= link_to 'プロフィールを編集する', edit_user_registration_path, class: 'user-edit-link' if current_user? %>
+      </div>
+    </div>
+  </div>
+<% else %> 
+  <p>退会されたユーザーです。</p>
+<% end %> 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,66 @@
+ja:
+  devise:
+    confirmations:
+      confirmed: 'アカウントを登録しました。'
+      send_instructions: 'アカウントの有効化について数分以内にメールでご連絡します。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。"
+    failure:
+      already_authenticated: 'すでにログインしています。'
+      inactive: 'アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。'
+      invalid: "%{authentication_keys} もしくはパスワードが不正です。"
+      locked: 'あなたのアカウントは凍結されています。'
+      last_attempt: 'あなたのアカウントが凍結される前に、複数回の操作がおこなわれています。'
+      not_found_in_database: "%{authentication_keys} もしくはパスワードが不正です。"
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+      unauthenticated: 'アカウント登録もしくはログインしてください。'
+      unconfirmed: 'メールアドレスの本人確認が必要です。'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの有効化について'
+      reset_password_instructions:
+        subject: 'パスワードの再設定について'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除について'
+      password_change:
+        subject: 'パスワードの変更について'
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      no_token: "このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。"
+      send_instructions: 'パスワードの再設定について数分以内にメールでご連絡いたします。'
+      send_paranoid_instructions: "あなたのメールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。"
+      updated: 'パスワードが正しく変更されました。'
+      updated_not_active: 'パスワードが正しく変更されました。'
+    registrations:
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+      signed_up: 'アカウント登録が完了しました。'
+      signed_up_but_inactive: 'ログインするためには、アカウントを有効化してください。'
+      signed_up_but_locked: 'アカウントが凍結されているためログインできません。'
+      signed_up_but_unconfirmed: '本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。'
+      update_needs_confirmation: 'アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。'
+      updated: 'アカウント情報を変更しました。'
+    sessions:
+      signed_in: 'ログインしました。'
+      signed_out: 'ログアウトしました。'
+      already_signed_out: '既にログアウト済みです。'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      send_paranoid_instructions: 'アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+      unlocked: 'アカウントを凍結解除しました。'
+  errors:
+    messages:
+      already_confirmed: 'は既に登録済みです。ログインしてください。'
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: 'の有効期限が切れました。新しくリクエストしてください。'
+      not_found: 'は見つかりませんでした。'
+      not_locked: 'は凍結されていません。'
+      not_saved:
+        one: "エラーが発生したため %{resource} は保存されませんでした:"
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした:"
+      taken: "は既に使用されています。"
+      blank: "が入力されていません。"
+      too_short: "は%{count}文字以上に設定して下さい。"
+      too_long: "は%{count}文字以下に設定して下さい。"
+      invalid: "は有効でありません。"
+      confirmation: "が内容とあっていません。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -30,21 +30,6 @@ ja:
         profile: 自己紹介
         phone_number: 電話番号
         remember_me: ログインしたままにする
-  devise:
-    registrations:
-      user:
-        signed_up: ユーザー登録しました
-        updated: ユーザー情報を更新しました
-    sessions:
-      user:
-        signed_in: ログインしました
-        signed_out: ログアウトしました
-    omniauth_callbacks:
-      user:
-        success: ログインしました
-    failure:
-      user:
-        unauthenticated: ログインしてください
   time:
     formats:
       default: "%Y年%m月%d日"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
   }
 
   resources :users, only: :show do
-    resources :reservations, only: [:index, :show, :update, :destroy]
     get 'reservations/canceled', to: 'reservations#canceled_index', as: 'canceled_reservations'
+    resources :reservations, only: [:index, :show, :update, :destroy]
   end
 
   resources :events do
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
     get 'reservations', to: 'dashboards#reservation_index', as: 'dashboard_reservations'
     get 'events', to: 'dashboards#event_index', as: 'dashboard_events'
     get 'customers', to: 'dashboards#customer_index', as: 'dashboard_customers'
-    get 'customers/:id', to: 'dashboards#customer_reservations', as: 'customer_reservations'
+    get 'customers/:customer_id', to: 'dashboards#customer_reservations', as: 'customer_reservations'
   end
+
+  resource :retirements, only: [:new, :create]
 end

--- a/db/migrate/20221214101339_add_discarded_at_to_users.rb
+++ b/db/migrate/20221214101339_add_discarded_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddDiscardedAtToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :discarded_at, :datetime
+    add_index :users, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_14_143449) do
+ActiveRecord::Schema.define(version: 2022_12_14_101339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,7 +80,9 @@ ActiveRecord::Schema.define(version: 2022_11_14_143449) do
     t.string "nickname"
     t.string "phone_number"
     t.text "profile"
+    t.datetime "discarded_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["provider"], name: "index_users_on_provider", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/test/controllers/retirements_controller_test.rb
+++ b/test/controllers/retirements_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class RetirementsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get retirements_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get retirements_create_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## やったこと
- Retirementsコントローラとビューを作成し退会手続きを集約
- Userの退会に論理削除を採用
  - 論理削除を容易にするためDiscard gemを導入
  - 退会するユーザーの個人情報をマスクして、論理削除する`mask_and_discard`メソッド作成
    - 退会するユーザーの退会前バリデーションをおこうなう`check_all_events_finished`メソッドを作成
      - ユーザー関連データ取得メソッド`created_event_hosted_dates`, `participating_event_hosted_dates`を作成  
    - 退会するユーザーの個人情報をマスクする`mask_personal_data!`メソッドを作成
   - 公開中イベントの取得メソッド`published`は、退会したオーナー作成のイベントを除外するよう修正
- 論理削除されたユーザーに対応してビューを変更
  - ユーザープロフィール画面
  - 予約したイベント一覧画面
  - キャンセルしたイベント一覧画面
  - オーナーダッシュボードの予約一覧画面   
- リファクタリング
  - 可読性向上のため、customer_reservationsアクションに渡すパラメータと、顧客の予約一覧取得メソッドを`reservations_by(customer)`に変更
  - User関連データを取得していた各種has_manyメソッドをインスタンスメソッドに変更
    - `created_event_reservations `
    - `customers`
  - deviseのlocalesを別ファイルで管理 
## やっていないこと（今後実装予定）
- 特に無し

## できるようになること（ユーザー目線）
- 条件に合う時のみ退会できるようになり、EventやReservation関連の整合性が保たれる
- 退会したユーザーも予約履歴に残るようになり、総予約数などの集計は引き続きできるようになる（ユーザー目線）

## できなくなること（ユーザ目線）
- 作成済み、参加済みの未開催イベントが存在するときは退会できなくなる

## 動作確認
- [x] 「退会」をクリックしたら退会確認画面に遷移する
- [x] 退会確認画面で、条件を満たしつつ「退会する」をクリックすると退会できる
- [x] 条件を満たさない場合はエラーメッセージが表示される
- [x] 公開している未終了イベントが存在するときは退会できない
- [x] 参加している未終了イベントが存在するときは退会できない（キャンセル済み除く）
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/87155363/206935471-29595d47-4eb4-4e2c-979e-76878c893a49.png">

- [x] 退会した時、ユーザーレコードは論理削除
- [x] 退会した時、ユーザーの個人情報はマスキング処理する
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/87155363/208227591-13903a22-80ad-4984-adf2-f365d3a043d5.png">

- [x] 退会したユーザーはダッシュボードの顧客一覧に表示させない
- [x] 退会したユーザーのイベントは表示させない
- [x] 退会したユーザーは「退会したユーザー」と表示される（予約したイベント一覧、ユーザープロフィール画面、オーナーダッシュボードの履歴内）
- [x] 退会したemailで再入会ができるが、データは新規作成する必要あり

ユーザープロフィール画面(/users/:id)
<img width="318" alt="image" src="https://user-images.githubusercontent.com/87155363/208227649-1465a58f-fb11-4f82-8408-ced9d660ade2.png">

作成したイベントごとの予約者一覧画面(/events/:id/reservations)
<img width="754" alt="image" src="https://user-images.githubusercontent.com/87155363/207039753-0d8fb560-2cef-4c03-98b7-426886f97b39.png">

close #47 