### PR TITLE
FactoryBotを導入しモデルSpecを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
+  gem 'factory_bot_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,11 @@ GEM
       activerecord (>= 4.2, < 8)
     erubi (1.11.0)
     execjs (2.8.1)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
+      railties (>= 3.0.0)
     faraday (2.6.0)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -311,6 +316,7 @@ DEPENDENCIES
   cocoon
   devise
   discard (~> 1.2)
+  factory_bot_rails
   font-awesome-sass (~> 6.2.0)
   hirb
   hirb-unicode

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  it 'is valid with a name, place, title, discription, price, required_time, capacity and is_published' do
+    new_event = FactoryBot.build(:event)
+    expect(new_event).to be_valid
+  end
+
+  it 'is invalid without a name' do
+    new_event = FactoryBot.build(:event, name: nil)
+    new_event.valid?
+    expect(new_event.errors[:name]).to include("が入力されていません。")
+  end
+
+  it 'is invalid without a place' do
+    new_event = FactoryBot.build(:event, place: nil)
+    new_event.valid?
+    expect(new_event.errors[:place]).to include("が入力されていません。")
+  end
+
+  it 'is invalid without a title' do
+    new_event = FactoryBot.build(:event, title: nil)
+    new_event.valid?
+    expect(new_event.errors[:title]).to include("が入力されていません。")
+  end
+
+  it 'is invalid without a discription' do
+    new_event = FactoryBot.build(:event, discription: nil)
+    new_event.valid?
+    expect(new_event.errors[:discription]).to include("が入力されていません。")
+  end
+
+  it 'is invalid without a price' do
+    new_event = FactoryBot.build(:event, price: nil)
+    new_event.valid?
+    expect(new_event.errors[:price]).to include("が入力されていません。")
+  end
+
+  it 'is invalid without a required_time' do
+    new_event = FactoryBot.build(:event, required_time: nil)
+    new_event.valid?
+    expect(new_event.errors[:required_time]).to include("が入力されていません。")
+  end
+
+  it 'is invalid without a capacity' do
+    new_event = FactoryBot.build(:event, capacity: nil)
+    new_event.valid?
+    expect(new_event.errors[:capacity]).to include("が入力されていません。")
+  end
+
+  it 'is invalid without a is_published' do
+    new_event = FactoryBot.build(:event, is_published: nil)
+    new_event.valid?
+    expect(new_event.errors[:is_published]).to include("は一覧にありません")
+  end
+
+  it 'is invalid with a longer name than maximum length 50' do
+    new_event = FactoryBot.build(:event, name: '*' * 51)
+    new_event.valid?
+    expect(new_event.errors[:name]).to include("は50文字以下に設定して下さい。")
+  end
+
+  it 'is invalid with a longer place than maximum length 100' do
+    new_event = FactoryBot.build(:event, place: '*' * 101)
+    new_event.valid?
+    expect(new_event.errors[:place]).to include("は100文字以下に設定して下さい。")
+  end
+
+  it 'is invalid with a longer title than maximum length 100' do
+    new_event = FactoryBot.build(:event, title: '*' * 101)
+    new_event.valid?
+    expect(new_event.errors[:title]).to include("は100文字以下に設定して下さい。")
+  end
+
+  it 'is invalid with a longer discription than maximum length 2000' do
+    new_event = FactoryBot.build(:event, discription: '*' * 2001)
+    new_event.valid?
+    expect(new_event.errors[:discription]).to include("は2000文字以下に設定して下さい。")
+  end
+
+  it 'is invalid with a longer price than maximum length 7' do
+    new_event = FactoryBot.build(:event, price: 10 ** 7)
+    new_event.valid?
+    expect(new_event.errors[:price]).to include("は7文字以下に設定して下さい。")
+  end
+
+  it 'is invalid with a longer required_time than maximum length 3' do
+    new_event = FactoryBot.build(:event, required_time: 10 ** 3)
+    new_event.valid?
+    expect(new_event.errors[:required_time]).to include("は3文字以下に設定して下さい。")
+  end
+
+  it 'is invalid with a longer capacity than maximum length 3' do
+    new_event = FactoryBot.build(:event, capacity: 10 ** 3)
+    new_event.valid?
+    expect(new_event.errors[:capacity]).to include("は3文字以下に設定して下さい。")
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -95,4 +95,20 @@ RSpec.describe Event, type: :model do
     new_event.valid?
     expect(new_event.errors[:capacity]).to include("は3文字以下に設定して下さい。")
   end
+
+  describe 'owner' do
+    before do
+      @user = FactoryBot.create(:user)
+      @event = FactoryBot.create(:event, owner: @user)
+    end
+
+    it 'is this user' do
+      expect(@event).to be_created_by(@user)
+    end
+
+    it 'is not other user' do
+      other_user = FactoryBot.create(:user)
+      expect(@event).to_not be_created_by(other_user)
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -96,6 +96,11 @@ RSpec.describe Event, type: :model do
     expect(new_event.errors[:capacity]).to include("は3文字以下に設定して下さい。")
   end
 
+  it 'can have many hosted_dates' do
+    event = FactoryBot.create(:event, :with_hosted_dates)
+    expect(event.hosted_dates.length).to eq 3
+  end
+
   describe 'owner' do
     before do
       @user = FactoryBot.create(:user)

--- a/spec/models/hosted_date_spec.rb
+++ b/spec/models/hosted_date_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe HostedDate, type: :model do
+  before do
+    @event = FactoryBot.create(:event)
+  end
+
+  it 'is valid when started_at is earlier then ended_at' do
+    hosted_date = @event.hosted_dates.build(
+      started_at: 1.day.since(DateTime.parse("09:00")),
+      ended_at: 1.day.since(DateTime.parse("10:00")),
+    )
+    expect(hosted_date).to be_valid
+  end
+
+  it 'is invalid when ended_at is earlier than started_at' do
+    hosted_date = @event.hosted_dates.build(
+      started_at: 1.day.since(DateTime.parse("10:00")),
+      ended_at: 1.day.since(DateTime.parse("09:00")),
+    )
+    hosted_date.valid?
+    expect(hosted_date.errors[:started_at]).to include('は終了時間よりも前に設定してください')
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,39 +2,26 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it 'is valid with an email and password' do
-    user = User.new(
-      email: 'test@example.com',
-      password: '112233445566'
-    )
+    user = FactoryBot.build(:user)
     user.valid?
     expect(user).to be_valid
   end
-
+  
   it 'is invalid without an email' do
-    user = User.new(
-      email: nil
-    )
+    user = FactoryBot.build(:user, email: nil)
     user.valid?
     expect(user.errors[:email]).to include("が入力されていません。")
   end
   
   it 'is invalid without a password' do
-    user = User.new(
-      password: nil
-    )
+    user = FactoryBot.build(:user, password: nil)
     user.valid?
     expect(user.errors[:password]).to include("が入力されていません。")
   end
 
   it "is invalid with a duplicate email address" do
-    User.create(
-      email: "taro@example.com",
-      password: "112233445566"
-    )
-    user = User.new(
-      email: "taro@example.com",
-      password: "112233445566"
-    )
+    FactoryBot.create(:user)
+    user = FactoryBot.build(:user)
     user.valid?
     expect(user.errors[:email]).to include{"はすでに登録済みです。"}
   end

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -9,5 +9,9 @@ FactoryBot.define do
     capacity { 5 }
     is_published { true }
     association :owner
+
+    trait :with_hosted_dates do
+      after(:create) { |event| create_list(:hosted_date, 3, event: event) }
+    end
   end
 end

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :event do
+    name { 'バスソルト作り' }
+    place { '金魚亭' }
+    title { '心身共にリラックスできるバスソルトを作りましょう' }
+    discription { '見た目も可愛くてリラックス以外の効能もあります' }
+    price { 500 }
+    required_time { 30 }
+    capacity { 5 }
+    is_published { true }
+    association :owner
+  end
+end

--- a/test/factories/hosted_dates.rb
+++ b/test/factories/hosted_dates.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :hosted_date do
+    sequence(:started_at) { |n| 1.day.since(DateTime.parse("0#{n}:00")) }
+    sequence(:ended_at) { |n| 1.day.since(DateTime.parse("0#{n+1}:00")) }
+    association :event
+  end
+end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user, aliases: [:owner] do
+    sequence(:email) { |n| "tester#{n}@example.com"}
+    password { '123456' }
+  end
+end


### PR DESCRIPTION
## やったこと
- Eventモデルスペックを追加
  - バリデーション検証
  - has_manyアソシエーション検証
  - `created_by? `メソッド検証
- HostedDateモデルスペックを追加
  - 独自バリデーション`start_at_should_be_before_ended_at`検証  
- Userモデルスペック修正
  - スペック内のuserをFactoryBotで生成するよう修正  

## やっていないこと（今後実装予定）
- HostedDateのuniqunessバリデーションとその検証スペックを追加

## できるようになること（開発者目線）
- FactoryBotにより、柔軟にテストデータを生成することができる。

## できなくなること（ユーザ目線）
- 特に無し

## 動作確認
```
$ bundle exec rspec

Event
  is valid with a name, place, title, discription, price, required_time, capacity and is_published
  is invalid without a name
  is invalid without a place
  is invalid without a title
  is invalid without a discription
  is invalid without a price
  is invalid without a required_time
  is invalid without a capacity
  is invalid without a is_published
  is invalid with a longer name than maximum length 50
  is invalid with a longer place than maximum length 100
  is invalid with a longer title than maximum length 100
  is invalid with a longer discription than maximum length 2000
  is invalid with a longer price than maximum length 7
  is invalid with a longer required_time than maximum length 3
  is invalid with a longer capacity than maximum length 3
  can have many hosted_dates
  owner
    is this user
    is not other user

HostedDate
  is valid when started_at is earlier then ended_at
  is invalid when ended_at is earlier than started_at

User
  is valid with an email and password
  is invalid without an email
  is invalid without a password
  is invalid with a duplicate email address

Finished in 0.22912 seconds (files took 0.89687 seconds to load)
25 examples, 0 failures

```