### PR TITLE
HostedDateにバリデーションを追加

### DIFF
--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -5,8 +5,9 @@ class HostedDate < ApplicationRecord
   validates :started_at, presence: true
   validates :ended_at, presence: true
   validates :event_id, uniqueness: { scope: [:started_at, :ended_at] }
+  validate :started_at_should_be_after_now
   validate :srart_at_should_be_before_ended_at
-  validate :hosted_date_should_not_be_overlapping, if: :new_or_start_or_end_time_changed
+  validate :hosted_date_should_not_be_overlapping
   
   def available?
     true unless capacity_left.zero?
@@ -18,16 +19,18 @@ class HostedDate < ApplicationRecord
   
   private
 
+  def started_at_should_be_after_now
+    if started_at <= DateTime.now
+      errors.add(:started_at, 'は現在時刻より後に設定してください')
+    end
+  end
+
   def srart_at_should_be_before_ended_at
     return unless started_at && ended_at
 
     if started_at >= ended_at
       errors.add(:started_at, 'は終了時間よりも前に設定してください')
     end
-  end
-
-  def new_or_start_or_end_time_changed
-    new_record? || will_save_change_to_start_time? || will_save_change_to_end_time?
   end
 
   def hosted_date_should_not_be_overlapping

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -4,6 +4,7 @@ class HostedDate < ApplicationRecord
 
   validates :started_at, presence: true
   validates :ended_at, presence: true
+  validates :event_id, uniqueness: { scope: [:started_at, :ended_at] }
   validate :srart_at_should_be_before_ended_at
   
   def available?

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -6,6 +6,7 @@ class HostedDate < ApplicationRecord
   validates :ended_at, presence: true
   validates :event_id, uniqueness: { scope: [:started_at, :ended_at] }
   validate :srart_at_should_be_before_ended_at
+  validate :hosted_date_should_not_be_overlapping, if: :new_or_start_or_end_time_changed
   
   def available?
     true unless capacity_left.zero?
@@ -24,4 +25,20 @@ class HostedDate < ApplicationRecord
       errors.add(:started_at, 'は終了時間よりも前に設定してください')
     end
   end
+
+  def new_or_start_or_end_time_changed
+    new_record? || will_save_change_to_start_time? || will_save_change_to_end_time?
+  end
+
+  def hosted_date_should_not_be_overlapping
+    return unless started_at && ended_at
+
+    if HostedDate.where(event_id: event.id)
+      .where('started_at < ?', ended_at)
+      .where('ended_at > ?', started_at)
+      .where.not(id: id).exists?
+
+      errors.add(:base, '他の開催日時と重複しています。')
+    end
+  end 
 end

--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -4,7 +4,7 @@ class HostedDate < ApplicationRecord
 
   validates :started_at, presence: true
   validates :ended_at, presence: true
-  validates :event_id, uniqueness: { scope: [:started_at, :ended_at] }
+  validates :event_id, uniqueness: { scope: [:started_at, :ended_at], message: '内に既に存在する開催日時です。' }
   validate :started_at_should_be_after_now
   validate :srart_at_should_be_before_ended_at
   validate :hosted_date_should_not_be_overlapping
@@ -41,7 +41,7 @@ class HostedDate < ApplicationRecord
       .where('ended_at > ?', started_at)
       .where.not(id: id).exists?
 
-      errors.add(:base, '他の開催日時と重複しています。')
+      errors.add(:base, 'が既に存在する期間と重複しています。')
     end
   end 
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,6 +19,8 @@ ja:
         comment: 連絡事項
         hosted_date_id: 日時
       hosted_dates:
+        base: 開催日時
+        event_id: イベント
         started_at: 開始日時
         ended_at: 終了日時
       user:

--- a/spec/models/hosted_date_spec.rb
+++ b/spec/models/hosted_date_spec.rb
@@ -5,18 +5,35 @@ RSpec.describe HostedDate, type: :model do
     @event = FactoryBot.create(:event)
   end
 
-  it 'is valid when started_at is earlier than ended_at' do
+  it 'is valid when stated_at is after now' do
     hosted_date = @event.hosted_dates.build(
-      started_at: 1.day.since(DateTime.parse("09:00")),
-      ended_at: 1.day.since(DateTime.parse("10:00")),
+      started_at: 1.minute.from_now,
+      ended_at: 1.hour.from_now
     )
     expect(hosted_date).to be_valid
   end
 
-  it 'is invalid when ended_at is earlier than started_at' do
+  it 'is invalid when stated_at is before now' do
     hosted_date = @event.hosted_dates.build(
-      started_at: 1.day.since(DateTime.parse("10:00")),
-      ended_at: 1.day.since(DateTime.parse("09:00")),
+      started_at: 1.minute.ago,
+      ended_at: 1.hour.from_now
+    )
+    hosted_date.valid?
+    expect(hosted_date.errors[:started_at]).to include('は現在時刻より後に設定してください')
+  end
+
+  it 'is valid when started_at is before ended_at' do
+    hosted_date = @event.hosted_dates.build(
+      started_at: 1.day.since(DateTime.parse('09:00')),
+      ended_at: 1.day.since(DateTime.parse('10:00'))
+    )
+    expect(hosted_date).to be_valid
+  end
+
+  it 'is invalid when ended_at is before started_at' do
+    hosted_date = @event.hosted_dates.build(
+      started_at: 1.day.since(DateTime.parse('10:00')),
+      ended_at: 1.day.since(DateTime.parse('09:00'))
     )
     hosted_date.valid?
     expect(hosted_date.errors[:started_at]).to include('は終了時間よりも前に設定してください')

--- a/spec/models/hosted_date_spec.rb
+++ b/spec/models/hosted_date_spec.rb
@@ -21,4 +21,11 @@ RSpec.describe HostedDate, type: :model do
     hosted_date.valid?
     expect(hosted_date.errors[:started_at]).to include('は終了時間よりも前に設定してください')
   end
+
+  it 'is invalid when both stared_at and ended_at are the same datetime' do
+    FactoryBot.create(:hosted_date, :from_9_to_10, event: @event)
+    hosted_date = FactoryBot.build(:hosted_date, :from_9_to_10, event: @event)
+    hosted_date.valid?
+    expect(hosted_date.errors[:event_id]).to include('はすでに登録済みです')
+  end
 end

--- a/spec/models/hosted_date_spec.rb
+++ b/spec/models/hosted_date_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe HostedDate, type: :model do
     FactoryBot.create(:hosted_date, :from_9_to_10, event: @event)
     hosted_date = FactoryBot.build(:hosted_date, :from_9_to_10, event: @event)
     hosted_date.valid?
-    expect(hosted_date.errors[:event_id]).to include('はすでに登録済みです')
+    expect(hosted_date.errors[:event_id]).to include('内に既に存在する開催日時です。')
   end
   
   describe 'overlapping validation for the default held from 9:00 to 10:00' do
@@ -73,25 +73,25 @@ RSpec.describe HostedDate, type: :model do
       it 'is invalid when held from 8:30 to 9:30' do
         hosted_date = FactoryBot.build(:hosted_date, :from_8_30_to_9_30, event: @event)
         hosted_date.valid?
-        expect(hosted_date.errors[:base]).to include('他の開催日時と重複しています。')
+        expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end
       
       it 'is invalid when held from 8:50 to 10:10' do
         hosted_date = FactoryBot.build(:hosted_date, :from_8_50_to_10_10, event: @event)
         hosted_date.valid?
-        expect(hosted_date.errors[:base]).to include('他の開催日時と重複しています。')
+        expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end
       
       it 'is invalid when held from 9:10 to 9:50' do
         hosted_date = FactoryBot.build(:hosted_date, :from_9_10_to_9_50, event: @event)
         hosted_date.valid?
-        expect(hosted_date.errors[:base]).to include('他の開催日時と重複しています。')
+        expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end
       
       it 'is invalid when held from 9:30 to 10:30' do
         hosted_date = FactoryBot.build(:hosted_date, :from_9_30_to_10_30, event: @event)
         hosted_date.valid?
-        expect(hosted_date.errors[:base]).to include('他の開催日時と重複しています。')
+        expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe User, type: :model do
   end
 
   it "is invalid with a duplicate email address" do
-    FactoryBot.create(:user)
-    user = FactoryBot.build(:user)
+    FactoryBot.create(:user, email: 'test@example.com')
+    user = FactoryBot.build(:user, email: 'test@example.com')
     user.valid?
-    expect(user.errors[:email]).to include{"はすでに登録済みです。"}
+    expect(user.errors[:email]).to include("はすでに登録済みです")
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe User, type: :model do
   it 'is invalid without an email' do
     user = FactoryBot.build(:user, email: nil)
     user.valid?
-    expect(user.errors[:email]).to include("が入力されていません。")
+    expect(user.errors[:email]).to include('が入力されていません。')
   end
   
   it 'is invalid without a password' do
     user = FactoryBot.build(:user, password: nil)
     user.valid?
-    expect(user.errors[:password]).to include("が入力されていません。")
+    expect(user.errors[:password]).to include('が入力されていません。')
   end
 
   it "is invalid with a duplicate email address" do
     FactoryBot.create(:user, email: 'test@example.com')
     user = FactoryBot.build(:user, email: 'test@example.com')
     user.valid?
-    expect(user.errors[:email]).to include("はすでに登録済みです")
+    expect(user.errors[:email]).to include('はすでに登録済みです')
   end
 end

--- a/test/factories/hosted_dates.rb
+++ b/test/factories/hosted_dates.rb
@@ -3,5 +3,10 @@ FactoryBot.define do
     sequence(:started_at) { |n| 1.day.since(DateTime.parse("0#{n}:00")) }
     sequence(:ended_at) { |n| 1.day.since(DateTime.parse("0#{n+1}:00")) }
     association :event
+
+    trait :from_9_to_10 do
+      started_at { 1.day.since(DateTime.parse("09:00")) }
+      ended_at { 1.day.since(DateTime.parse("10:00")) }
+    end
   end
 end

--- a/test/factories/hosted_dates.rb
+++ b/test/factories/hosted_dates.rb
@@ -8,5 +8,35 @@ FactoryBot.define do
       started_at { 1.day.since(DateTime.parse("09:00")) }
       ended_at { 1.day.since(DateTime.parse("10:00")) }
     end
+
+    trait :from_8_to_9 do
+      started_at { 1.day.since(DateTime.parse("08:00")) }
+      ended_at { 1.day.since(DateTime.parse("09:00")) }
+    end
+
+    trait :from_10_to_11 do
+      started_at { 1.day.since(DateTime.parse("10:00")) }
+      ended_at { 1.day.since(DateTime.parse("11:00")) }
+    end
+
+    trait :from_8_30_to_9_30 do
+      started_at { 1.day.since(DateTime.parse("08:30")) }
+      ended_at { 1.day.since(DateTime.parse("09:30")) }
+    end
+
+    trait :from_8_50_to_10_10 do
+      started_at { 1.day.since(DateTime.parse("08:50")) }
+      ended_at { 1.day.since(DateTime.parse("10:10")) }
+    end
+  
+    trait :from_9_10_to_9_50 do
+      started_at { 1.day.since(DateTime.parse("09:10")) }
+      ended_at { 1.day.since(DateTime.parse("09:50")) }
+    end
+  
+    trait :from_9_30_to_10_30 do
+      started_at { 1.day.since(DateTime.parse("09:30")) }
+      ended_at { 1.day.since(DateTime.parse("10:30")) }
+    end
   end
 end

--- a/test/factories/hosted_dates.rb
+++ b/test/factories/hosted_dates.rb
@@ -5,38 +5,38 @@ FactoryBot.define do
     association :event
 
     trait :from_9_to_10 do
-      started_at { 1.day.since(DateTime.parse("09:00")) }
-      ended_at { 1.day.since(DateTime.parse("10:00")) }
+      started_at { 1.day.since(DateTime.parse('09:00')) }
+      ended_at { 1.day.since(DateTime.parse('10:00')) }
     end
 
     trait :from_8_to_9 do
-      started_at { 1.day.since(DateTime.parse("08:00")) }
-      ended_at { 1.day.since(DateTime.parse("09:00")) }
+      started_at { 1.day.since(DateTime.parse('08:00')) }
+      ended_at { 1.day.since(DateTime.parse('09:00')) }
     end
 
     trait :from_10_to_11 do
-      started_at { 1.day.since(DateTime.parse("10:00")) }
-      ended_at { 1.day.since(DateTime.parse("11:00")) }
+      started_at { 1.day.since(DateTime.parse('10:00')) }
+      ended_at { 1.day.since(DateTime.parse('11:00')) }
     end
 
     trait :from_8_30_to_9_30 do
-      started_at { 1.day.since(DateTime.parse("08:30")) }
-      ended_at { 1.day.since(DateTime.parse("09:30")) }
+      started_at { 1.day.since(DateTime.parse('08:30')) }
+      ended_at { 1.day.since(DateTime.parse('09:30')) }
     end
 
     trait :from_8_50_to_10_10 do
-      started_at { 1.day.since(DateTime.parse("08:50")) }
-      ended_at { 1.day.since(DateTime.parse("10:10")) }
+      started_at { 1.day.since(DateTime.parse('08:50')) }
+      ended_at { 1.day.since(DateTime.parse('10:10')) }
     end
   
     trait :from_9_10_to_9_50 do
-      started_at { 1.day.since(DateTime.parse("09:10")) }
-      ended_at { 1.day.since(DateTime.parse("09:50")) }
+      started_at { 1.day.since(DateTime.parse('09:10')) }
+      ended_at { 1.day.since(DateTime.parse('09:50')) }
     end
   
     trait :from_9_30_to_10_30 do
-      started_at { 1.day.since(DateTime.parse("09:30")) }
-      ended_at { 1.day.since(DateTime.parse("10:30")) }
+      started_at { 1.day.since(DateTime.parse('09:30')) }
+      ended_at { 1.day.since(DateTime.parse('10:30')) }
     end
   end
 end


### PR DESCRIPTION
## やったこと
1. event_id, started_at, ended_atの組み合わせが一意になるようユニーク制約を追加
2. 現在より前にstarted_atを設定できない制約を追加
3. 同じイベント内で登録済みの時間帯と重複させない制約を追加
4. 1~3をテストするspecを追加
5. User スペック "is invalid with a duplicate email address"を修正

## やっていないこと（今後実装予定）
- 特に無し

## できるようになること（ユーザー目線）
-フォームで意図せず整合性のない時間帯を登録しようとしたとき、バリデーションエラーで気づくことができる

## できなくなること（ユーザ目線）
- 上記制約を逸脱した日時を意図的に登録できなくなる

## 動作確認
### ブラウザでの確認
現在より前のstarted_atかつ重複した時刻で登録しようとすると、以下の通り正常にエラーが発生することを確認。
入力した日時（22/12/19 15:50現在）
<img width="920" alt="image" src="https://user-images.githubusercontent.com/87155363/208364982-eb5eabdf-8a6d-40ed-852c-7a3c587e4580.png">
更新時のエラーメッセージ（22/12/19 15:50現在）
<img width="918" alt="image" src="https://user-images.githubusercontent.com/87155363/208364932-1c8ac747-762c-4865-8787-9b3ba6a64c95.png">
### RSpecでの確認
```
$ bundle exec rspec 

略

HostedDate
  is valid when stated_at is after now
  is invalid when stated_at is before now
  is valid when started_at is before ended_at
  is invalid when ended_at is before started_at
  is valid when stared_at and ended_at are unique
  is invalid when both stared_at and ended_at are not unique
  overlapping validation for the default held from 9:00 to 10:00
    not overlapping
      is valid when held from 8:00 to 9:00
      is valid when held from 10:00 to 11:00
    overlapping
      is invalid when held from 8:30 to 9:30
      is invalid when held from 8:50 to 10:10
      is invalid when held from 9:10 to 9:50
      is invalid when held from 9:30 to 10:30

User
  is valid with an email and password
  is invalid without an email
  is invalid without a password
  is invalid with a duplicate email address

Finished in 0.27095 seconds (files took 0.70792 seconds to load)
35 examples, 0 failures
```