### PR TITLE
Reservaitonスペックの追加とリファクタリング

### DIFF
--- a/app/models/hosted_date.rb
+++ b/app/models/hosted_date.rb
@@ -17,6 +17,10 @@ class HostedDate < ApplicationRecord
     event.capacity - reservations.reserved.count
   end
 
+  def reserved_by?(user)
+    reservations.exists?(user: user, is_canceled: false)
+  end
+
   private
 
   def started_at_should_be_after_now

--- a/app/views/events/_hosted_date_show.html.erb
+++ b/app/views/events/_hosted_date_show.html.erb
@@ -3,7 +3,7 @@
     <%= icon('far', 'calendar-days', class: 'detail-icon')%>
     <%= format_date(date) %>
   </th>
-  <% if @event.created_by?(current_user) %>
+  <% if @event.created_by?(current_user) || date.reserved_by?(current_user)%>
     <td>
       <%= icon('far', 'circle', class: 'detail-icon') %>
       <span class="rest-capacity">残り<%= date.capacity_left %> 人</span>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe EventsController, type: :controller do
 
       it 'retunes a 302 response' do
         patch :update, params: { id: event.id, event: event_params }
-        expect(response).to have_http_status'302'
+        expect(response).to have_http_status '302'
       end
       
       it 'redirects to the sign-in page' do
@@ -178,7 +178,7 @@ RSpec.describe EventsController, type: :controller do
 
       it 'retunes a 302 response' do
         delete :destroy, params: { id: event.id }
-        expect(response).to have_http_status'302'
+        expect(response).to have_http_status '302'
       end
       
       it 'redirects to the sign-in page' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -3,18 +3,16 @@ require 'rails_helper'
 RSpec.describe EventsController, type: :controller do
   describe '#index' do
     context 'as an authenticated user' do
-      before do
-        @user = FactoryBot.create(:user)
-      end
+      let(:user) { create(:user) }
 
       it 'resoponds successfully' do
-        sign_in @user
+        sign_in user
         get :index
         expect(response).to be_successful
       end
 
       it 'returns a 200 response' do
-        sign_in @user
+        sign_in user
         get :index
         expect(response).to have_http_status '200'
       end
@@ -35,40 +33,38 @@ RSpec.describe EventsController, type: :controller do
 
   describe '#create' do
     context 'as an authenticated user' do
-      before do
-        @user = FactoryBot.create(:user)
-      end
+      let(:user) { create(:user) }
 
       context 'with valid attributes' do
         it 'adds a event' do
-          event_params = FactoryBot.attributes_for(:event, :with_hosted_dates)
-          sign_in @user
+          event_params = attributes_for(:event, :with_hosted_dates)
+          sign_in user
           expect {
-            post :create, params: { event: event_params, owner: @user }
-          }.to change(@user.created_events, :count).by(1)
+            post :create, params: { event: event_params, owner: user }
+          }.to change(user.created_events, :count).by(1)
         end
       end
 
       context 'with invalid attributes' do
         it 'does not add a event' do
-          event_params = FactoryBot.attributes_for(:event, :with_hosted_dates, name: nil)
-          sign_in @user
+          event_params = attributes_for(:event, :with_hosted_dates, name: nil)
+          sign_in user
           expect {
-            post :create, params: { event: event_params, owner: @user }
-          }.to_not change(@user.created_events, :count)
+            post :create, params: { event: event_params, owner: user }
+          }.to_not change(user.created_events, :count)
         end
       end
     end
 
     context 'as a guest' do
+      let(:event_params) { attributes_for(:event, :with_hosted_dates) }
+
       it 'returns a 302 response' do 
-        event_params = FactoryBot.attributes_for(:event, :with_hosted_dates)
         post :create, params: { event: event_params }
         expect(response).to have_http_status '302'
       end
 
       it 'redirect to the sign-in page' do
-        event_params = FactoryBot.attributes_for(:event, :with_hosted_dates)
         post :create, params: { event: event_params }
         expect(response).to redirect_to '/users/sign_in'
       end
@@ -77,36 +73,32 @@ RSpec.describe EventsController, type: :controller do
 
   describe '#show' do
     context 'as an authenticated user' do
-      before do
-        @user = FactoryBot.create(:user)
-        @event = FactoryBot.create(:event, :with_hosted_dates)
-      end
+      let(:user) { create(:user) }
+      let(:event) { create(:event, :with_hosted_dates) }
 
       it 'responds successfully' do
-        sign_in @user
-        get :show, params: { id: @event.id }
+        sign_in user
+        get :show, params: { id: event.id }
         expect(response).to be_successful
       end
 
       it 'returns a 200 response' do
-        sign_in @user
-        get :show, params: { id: @event.id }
+        sign_in user
+        get :show, params: { id: event.id }
         expect(response).to have_http_status '200'
       end
     end
 
     context 'as a guest' do
-      before do
-        @event = FactoryBot.create(:event, :with_hosted_dates)
-      end
+      let(:event) { create(:event, :with_hosted_dates) }
 
       it 'responds successfully' do
-        get :show, params: { id: @event.id }
+        get :show, params: { id: event.id }
         expect(response).to be_successful
       end
 
       it 'returns a 200 response' do
-        get :show, params: { id: @event.id }
+        get :show, params: { id: event.id }
         expect(response).to have_http_status '200'
       end
     end
@@ -114,50 +106,42 @@ RSpec.describe EventsController, type: :controller do
 
   describe '#update' do
     context 'as an authorized user' do
-      before do
-        @user = FactoryBot.create(:user)
-        @event = FactoryBot.create(:event, :with_hosted_dates, owner: @user, name: 'old_name')
-      end
+      let(:user) { create(:user) }
+      let(:event) { create(:event, :with_hosted_dates, owner: user, name: 'old_name') }
 
       it 'updates the event' do
-        event_params = FactoryBot.attributes_for(:event, :with_hosted_dates, name: 'new_name')
-        sign_in @user
-        patch :update, params: { id: @event.id, event: event_params }
-        expect(@event.reload.name).to eq 'new_name'
+        event_params = attributes_for(:event, :with_hosted_dates, name: 'new_name')
+        sign_in user
+        patch :update, params: { id: event.id, event: event_params }
+        expect(event.reload.name).to eq 'new_name'
       end
     end
 
     context 'as an unauthorized user' do
-      before do
-        @user = FactoryBot.create(:user)
-        other_user = FactoryBot.create(:user)
-        @event = FactoryBot.create(:event, :with_hosted_dates, owner: other_user, name: 'old_name')
-      end
+      let(:user) { create(:user) }
+      let(:other_user) { create(:user) }
+      let(:event) { create(:event, :with_hosted_dates, owner: other_user, name: 'old_name') }
       
       it 'raises exeption error' do
-        event_params = FactoryBot.attributes_for(:event, :with_hosted_dates, name: 'new_name')
-        sign_in @user
+        event_params = attributes_for(:event, :with_hosted_dates, name: 'new_name')
+        sign_in user
         expect {
-          patch :update, params: { id: @event.id, event: event_params }
+          patch :update, params: { id: event.id, event: event_params }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'as a guest' do
-      before do
-        user = FactoryBot.create(:user)
-        @event = FactoryBot.create(:event, :with_hosted_dates, owner: user, name: 'old_name')
-      end
+      let(:event) { create(:event, :with_hosted_dates, name: 'old_name') }
+      let(:event_params) { attributes_for(:event, :with_hosted_dates, name: 'new_event') }
 
       it 'retunes a 302 response' do
-        event_params = FactoryBot.attributes_for(:event, :with_hosted_dates, name: 'new_event')
-        patch :update, params: { id: @event.id, event: event_params }
+        patch :update, params: { id: event.id, event: event_params }
         expect(response).to have_http_status'302'
       end
       
       it 'redirects to the sign-in page' do
-        event_params = FactoryBot.attributes_for(:event, :with_hosted_dates, name: 'new_event')
-        patch :update, params: { id: @event.id, event: event_params }
+        patch :update, params: { id: event.id, event: event_params }
         expect(response).to redirect_to '/users/sign_in'
       end
     end
@@ -165,47 +149,40 @@ RSpec.describe EventsController, type: :controller do
 
   describe '#destroy' do
     context 'as an authorized user' do
-      before do
-        @user = FactoryBot.create(:user)
-        @event = FactoryBot.create(:event, :with_hosted_dates, owner: @user)
-      end
+      let(:user) { create(:user) }
+      let!(:event) { create(:event, :with_hosted_dates, owner: user) }
 
       it 'destroys the event' do
-        sign_in @user
+        sign_in user
         expect {
-          delete :destroy, params: { id: @event.id }
-        }.to change(@user.created_events, :count).by(-1)
+          delete :destroy, params: { id: event.id }
+        }.to change(user.created_events, :count).by(-1)
       end
     end
 
     context 'as an unauthorized user' do
-      before do
-        @user = FactoryBot.create(:user)
-        other_user = FactoryBot.create(:user)
-        @event = FactoryBot.create(:event, :with_hosted_dates, owner: other_user)
-      end
+      let(:user) { create(:user) }
+      let(:other_user) { create(:user) }
+      let!(:event) { create(:event, :with_hosted_dates, owner: other_user) }
       
       it 'raises exeption error' do
-        sign_in @user
+        sign_in user
         expect {
-          delete :destroy, params: { id: @event.id }
+          delete :destroy, params: { id: event.id }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     context 'as a guest' do
-      before do
-        user = FactoryBot.create(:user)
-        @event = FactoryBot.create(:event, :with_hosted_dates, owner: user)
-      end
+      let(:event) { create(:event, :with_hosted_dates) }
 
       it 'retunes a 302 response' do
-        delete :destroy, params: { id: @event.id }
+        delete :destroy, params: { id: event.id }
         expect(response).to have_http_status'302'
       end
       
       it 'redirects to the sign-in page' do
-        delete :destroy, params: { id: @event.id }
+        delete :destroy, params: { id: event.id }
         expect(response).to redirect_to '/users/sign_in'
       end
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -102,18 +102,16 @@ RSpec.describe Event, type: :model do
   end
 
   describe 'owner' do
-    before do
-      @user = create(:user)
-      @event = create(:event, owner: @user)
-    end
+    let(:user) { create(:user) }
+    let(:event) { create(:event, owner: user) }
 
     it 'is this user' do
-      expect(@event).to be_created_by(@user)
+      expect(event).to be_created_by(user)
     end
 
     it 'is not other user' do
       other_user = create(:user)
-      expect(@event).to_not be_created_by(other_user)
+      expect(event).to_not be_created_by(other_user)
     end
   end
 end

--- a/spec/models/hosted_date_spec.rb
+++ b/spec/models/hosted_date_spec.rb
@@ -22,16 +22,16 @@ RSpec.describe HostedDate, type: :model do
 
   it 'is valid when started_at is before ended_at' do
     hosted_date = event.hosted_dates.build(
-      started_at: 1.day.since(DateTime.parse('09:00')),
-      ended_at: 1.day.since(DateTime.parse('10:00'))
+      started_at: 1.day.since(Time.zone.parse('09:00')),
+      ended_at: 1.day.since(Time.zone.parse('10:00'))
     )
     expect(hosted_date).to be_valid
   end
 
   it 'is invalid when ended_at is before started_at' do
     hosted_date = event.hosted_dates.build(
-      started_at: 1.day.since(DateTime.parse('10:00')),
-      ended_at: 1.day.since(DateTime.parse('09:00'))
+      started_at: 1.day.since(Time.zone.parse('10:00')),
+      ended_at: 1.day.since(Time.zone.parse('09:00'))
     )
     hosted_date.valid?
     expect(hosted_date.errors[:started_at]).to include('は終了時間よりも前に設定してください')

--- a/spec/models/hosted_date_spec.rb
+++ b/spec/models/hosted_date_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe HostedDate, type: :model do
-  before do
-    @event = create(:event)
-  end
+  let(:event) { create(:event) }
 
   it 'is valid when stated_at is after now' do
-    hosted_date = @event.hosted_dates.build(
+    hosted_date =  event.hosted_dates.build(
       started_at: 1.minute.from_now,
       ended_at: 1.hour.from_now
     )
@@ -14,7 +12,7 @@ RSpec.describe HostedDate, type: :model do
   end
 
   it 'is invalid when stated_at is before now' do
-    hosted_date = @event.hosted_dates.build(
+    hosted_date = event.hosted_dates.build(
       started_at: 1.minute.ago,
       ended_at: 1.hour.from_now
     )
@@ -23,7 +21,7 @@ RSpec.describe HostedDate, type: :model do
   end
 
   it 'is valid when started_at is before ended_at' do
-    hosted_date = @event.hosted_dates.build(
+    hosted_date = event.hosted_dates.build(
       started_at: 1.day.since(DateTime.parse('09:00')),
       ended_at: 1.day.since(DateTime.parse('10:00'))
     )
@@ -31,7 +29,7 @@ RSpec.describe HostedDate, type: :model do
   end
 
   it 'is invalid when ended_at is before started_at' do
-    hosted_date = @event.hosted_dates.build(
+    hosted_date = event.hosted_dates.build(
       started_at: 1.day.since(DateTime.parse('10:00')),
       ended_at: 1.day.since(DateTime.parse('09:00'))
     )
@@ -40,56 +38,56 @@ RSpec.describe HostedDate, type: :model do
   end
 
   it 'is valid when stared_at and ended_at are unique' do
-    create(:hosted_date, :from_9_to_10, event: @event)
-    hosted_date = build(:hosted_date, :from_10_to_11, event: @event)
+    create(:hosted_date, :from_9_to_10, event: event)
+    hosted_date = build(:hosted_date, :from_10_to_11, event: event)
     expect(hosted_date).to be_valid
   end
 
   it 'is invalid when both stared_at and ended_at are not unique' do
-    create(:hosted_date, :from_9_to_10, event: @event)
-    hosted_date = build(:hosted_date, :from_9_to_10, event: @event)
+    create(:hosted_date, :from_9_to_10, event: event)
+    hosted_date = build(:hosted_date, :from_9_to_10, event: event)
     hosted_date.valid?
     expect(hosted_date.errors[:event_id]).to include('内に既に存在する開催日時です。')
   end
 
   describe 'overlapping validation for the default held from 9:00 to 10:00' do
     before do
-      create(:hosted_date, :from_9_to_10, event: @event)
+      create(:hosted_date, :from_9_to_10, event: event)
     end
 
     context 'not overlapping' do
       it 'is valid when held from 8:00 to 9:00' do
-        hosted_date = build(:hosted_date, :from_8_to_9, event: @event)
+        hosted_date = build(:hosted_date, :from_8_to_9, event: event)
         expect(hosted_date).to be_valid
       end
 
       it 'is valid when held from 10:00 to 11:00' do
-        hosted_date = build(:hosted_date, :from_10_to_11, event: @event)
+        hosted_date = build(:hosted_date, :from_10_to_11, event: event)
         expect(hosted_date).to be_valid
       end
     end
 
     context 'overlapping' do
       it 'is invalid when held from 8:30 to 9:30' do
-        hosted_date = build(:hosted_date, :from_8_30_to_9_30, event: @event)
+        hosted_date = build(:hosted_date, :from_8_30_to_9_30, event: event)
         hosted_date.valid?
         expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end
 
       it 'is invalid when held from 8:50 to 10:10' do
-        hosted_date = build(:hosted_date, :from_8_50_to_10_10, event: @event)
+        hosted_date = build(:hosted_date, :from_8_50_to_10_10, event: event)
         hosted_date.valid?
         expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end
 
       it 'is invalid when held from 9:10 to 9:50' do
-        hosted_date = build(:hosted_date, :from_9_10_to_9_50, event: @event)
+        hosted_date = build(:hosted_date, :from_9_10_to_9_50, event: event)
         hosted_date.valid?
         expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end
 
       it 'is invalid when held from 9:30 to 10:30' do
-        hosted_date = build(:hosted_date, :from_9_30_to_10_30, event: @event)
+        hosted_date = build(:hosted_date, :from_9_30_to_10_30, event: event)
         hosted_date.valid?
         expect(hosted_date.errors[:base]).to include('が既に存在する期間と重複しています。')
       end

--- a/spec/models/hosted_date_spec.rb
+++ b/spec/models/hosted_date_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe HostedDate, type: :model do
   let(:event) { create(:event) }
 
   it 'is valid when stated_at is after now' do
-    hosted_date =  event.hosted_dates.build(
+    hosted_date = event.hosted_dates.build(
       started_at: 1.minute.from_now,
       ended_at: 1.hour.from_now
     )

--- a/spec/models/reservation_spec.rb
+++ b/spec/models/reservation_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Reservation, type: :model do
+  context 'with comments' do
+    it 'is valid with a comment' do
+      reservation = build(:reservation, comment: '楽しみです')
+      reservation.valid?
+      expect(reservation).to be_valid
+    end
+    
+    it 'is valid with no comment' do
+      reservation = build(:reservation, comment: nil)
+      reservation.valid?
+      expect(reservation).to be_valid
+    end
+  end
+
+  context 'with hosted_dates' do
+    let(:event) { create(:event) }
+    let(:hosted_date1) { create(:hosted_date, :from_8_to_9, event: event) }
+    let(:hosted_date2) { create(:hosted_date, :from_10_to_11, event: event) }
+    let(:user) { create(:user) }
+
+    it 'is valid with the different hosted_date' do
+      user.reservations.create(
+        event: event,
+        hosted_date: hosted_date1
+      )
+      reservation = user.reservations.build(
+        event: event,
+        hosted_date: hosted_date2
+      )
+      expect(reservation).to be_valid
+    end
+
+    it 'is invalid with the same hosted_date' do
+      user.reservations.create(
+        event: event,
+        hosted_date: hosted_date1
+      )
+      reservation = user.reservations.build(
+        event: event,
+        hosted_date: hosted_date1
+      )
+      reservation.valid?
+      expect(reservation.errors[:hosted_date_id]).to include 'はすでに登録済みです' 
+    end
+  end
+  
+  context 'with is_canceled' do
+    it 'is canceld when is_canceled is true' do
+      reservation = build(:reservation, is_canceled: true)
+      expect(reservation).to be_is_canceled
+    end
+
+    it 'is not canceld when is_canceled is false' do
+      reservation = build(:reservation, is_canceled: false)
+      expect(reservation).to_not be_is_canceled
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
   config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::IntegrationHelpers, type: :system
 end

--- a/spec/support/login_support.rb
+++ b/spec/support/login_support.rb
@@ -1,0 +1,13 @@
+module LoginSupport
+  def sign_in_as(user)
+    visit root_path
+    click_link 'ログイン'  
+    fill_in 'メールアドレス', with: user.email
+    fill_in 'パスワード', with: user.password
+    click_button 'ログインする'
+  end
+end
+
+RSpec.configure do |config|
+  config.include LoginSupport
+end

--- a/spec/system/reservations_spec.rb
+++ b/spec/system/reservations_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+
+RSpec.describe "Reservations", type: :system, js: true do
+  context 'when user signs in' do
+    let(:owner) { create(:user) }
+    let!(:event) { create(:event, owner: owner) }
+    let!(:hosted_date1) { create(:hosted_date, :from_8_to_9, event: event) }
+    let!(:hosted_date2) { create(:hosted_date, :from_10_to_11, event: event) }
+    let(:user) { create(:user) }
+
+    scenario 'user reserves the event' do
+      sign_in user
+      visit root_path
+      click_link 'バスソルト作り'
+
+      expect {
+        within '.dates-section' do
+          within all('tr')[1] do
+            expect(page).to have_content '10:00 - 11:00'
+            expect(page).to have_content '残り2 人'
+            click_link '予約する'
+          end
+        end
+
+        fill_in '連絡事項', with: '楽しみにしています。'
+        click_button '予約を確定する'
+      }.to change(user.reservations, :count).by(1)
+
+      expect(page).to have_content '予約しました'
+      expect(page).to have_content '予約したココロミ'
+      expect(page).to have_content '10:00 - 11:00'
+    end
+
+    context 'after user reserves' do
+      before do
+        user.reservations.create(
+          event: event,
+          hosted_date: hosted_date1,
+        )
+
+        sign_in user
+      end
+
+      scenario 'user can not click the link to the same hosted_date for reservation' do
+        visit root_path
+        click_link 'バスソルト作り'
+
+        within '.dates-section' do
+          within all('tr')[0] do
+            expect(page).to have_content '08:00 - 09:00'
+            expect(page).to have_content '残り1 人'
+            expect(page).to have_selector '.disabled', text: '予約する'
+          end
+          within all('tr')[1] do
+            expect(page).to have_content '10:00 - 11:00'
+            expect(page).to have_content '残り2 人'
+            expect(page).to have_content '予約する'
+          end
+        end
+      end
+  
+      scenario 'user can change to other hosted_date for the reservation ' do
+        visit root_path
+        click_link '予約したココロミ'
+        expect(page).to have_content 'バスソルト作り'
+        expect(page).to have_content '08:00 - 09:00'
+        click_link 'バスソルト作り'
+        expect(page).to have_content '予約をキャンセルする'
+        select '10:00 - 11:00', from: 'reservation[hosted_date_id]'
+        click_button '予約内容を変更する'
+        expect(page).to have_content '予約を変更しました'
+        expect(page).to have_content '予約したココロミ'
+        expect(page).to have_content 'バスソルト作り'
+        expect(page).to have_content '10:00 - 11:00'
+      end
+    
+      scenario 'user can cancel the reservation' do
+        visit root_path
+        click_link '予約したココロミ'
+        expect(page).to have_content 'バスソルト作り'
+        expect(page).to have_content '08:00 - 09:00'
+        click_link 'バスソルト作り'
+        expect(page).to have_button '予約内容を変更する'
+        click_link 'この予約をキャンセルする'
+        page.accept_confirm
+        expect(page).to have_content '予約をキャンセルしました'
+        expect(user.reservations.find_by(hosted_date: hosted_date1).is_canceled).to be_truthy 
+        click_link 'キャンセル済み一覧'
+        expect(page).to have_content 'バスソルト作り'
+        expect(page).to have_content "キャンセル日：#{I18n.l  Time.current}"
+      end
+    end
+
+    context 'after other users reserve' do
+      let(:other_user1) { create(:user) }
+      let(:other_user2) { create(:user) }
+      
+      scenario 'user can not click the link to no capacity' do
+        other_user1.reservations.create(
+          event: event,
+          hosted_date: hosted_date2,
+        )
+        other_user2.reservations.create(
+          event: event,
+          hosted_date: hosted_date2,
+        )
+
+        sign_in user
+        visit root_path
+        click_link 'バスソルト作り'
+
+        within '.dates-section' do
+          within all('tr')[0] do
+            expect(page).to have_content '08:00 - 09:00'
+            expect(page).to have_content '残り2 人'
+            expect(page).to have_content '予約する'
+          end
+          within all('tr')[1] do
+            expect(page).to have_content '10:00 - 11:00'
+            expect(page).to have_content '残り0 人'
+            expect(page).to have_selector '.disabled', text: '予約する'
+          end
+        end
+      end
+    end
+  end
+
+  context 'when owner signs in' do
+    let(:owner) { create(:user) }
+    let(:event) { create(:event, owner: owner) }
+    let!(:hosted_date1) { create(:hosted_date, :from_8_to_9, event: event) }
+    let!(:hosted_date2) { create(:hosted_date, :from_10_to_11, event: event) }
+    let(:user) { create(:user) }
+    
+    before do
+      user.reservations.create(
+        event: event,
+        hosted_date: hosted_date1,
+      )
+    end
+
+    scenario 'owner can not click the link for own event reservation' do
+      sign_in owner
+      visit root_path
+      click_link 'バスソルト作り'
+
+      within '.dates-section' do
+        within all('tr')[0] do
+          expect(page).to have_content '08:00 - 09:00'
+          expect(page).to have_content '残り1 人'
+          expect(page).to have_selector '.disabled', text: '予約する'
+        end
+        within all('tr')[1] do
+          expect(page).to have_content '10:00 - 11:00'
+          expect(page).to have_content '残り2 人'
+          expect(page).to have_selector '.disabled', text: '予約する'
+        end
+      end
+    end
+  end
+end

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     discription { '見た目も可愛くてリラックス以外の効能もあります' }
     price { 500 }
     required_time { 30 }
-    capacity { 5 }
+    capacity { 2 }
     is_published { true }
     association :owner
 

--- a/test/factories/hosted_dates.rb
+++ b/test/factories/hosted_dates.rb
@@ -1,44 +1,44 @@
 FactoryBot.define do
   factory :hosted_date do
-    started_at = 1.day.since(Time.parse('00:00'))
-    ended_at = 1.day.since(Time.parse('01:00'))
+    started_at = 1.day.since(Time.zone.parse('00:00'))
+    ended_at = 1.day.since(Time.zone.parse('01:00'))
     sequence(:started_at) { |n| started_at + n.hour }
     sequence(:ended_at) { |n| ended_at + n.hour }
     association :event
 
     trait :from_9_to_10 do
-      started_at { 1.day.since(DateTime.parse('09:00')) }
-      ended_at { 1.day.since(DateTime.parse('10:00')) }
+      started_at { 1.day.since(Time.zone.parse('09:00')) }
+      ended_at { 1.day.since(Time.zone.parse('10:00')) }
     end
 
     trait :from_8_to_9 do
-      started_at { 1.day.since(DateTime.parse('08:00')) }
-      ended_at { 1.day.since(DateTime.parse('09:00')) }
+      started_at { 1.day.since(Time.zone.parse('08:00')) }
+      ended_at { 1.day.since(Time.zone.parse('09:00')) }
     end
 
     trait :from_10_to_11 do
-      started_at { 1.day.since(DateTime.parse('10:00')) }
-      ended_at { 1.day.since(DateTime.parse('11:00')) }
+      started_at { 1.day.since(Time.zone.parse('10:00')) }
+      ended_at { 1.day.since(Time.zone.parse('11:00')) }
     end
 
     trait :from_8_30_to_9_30 do
-      started_at { 1.day.since(DateTime.parse('08:30')) }
-      ended_at { 1.day.since(DateTime.parse('09:30')) }
+      started_at { 1.day.since(Time.zone.parse('08:30')) }
+      ended_at { 1.day.since(Time.zone.parse('09:30')) }
     end
 
     trait :from_8_50_to_10_10 do
-      started_at { 1.day.since(DateTime.parse('08:50')) }
-      ended_at { 1.day.since(DateTime.parse('10:10')) }
+      started_at { 1.day.since(Time.zone.parse('08:50')) }
+      ended_at { 1.day.since(Time.zone.parse('10:10')) }
     end
 
     trait :from_9_10_to_9_50 do
-      started_at { 1.day.since(DateTime.parse('09:10')) }
-      ended_at { 1.day.since(DateTime.parse('09:50')) }
+      started_at { 1.day.since(Time.zone.parse('09:10')) }
+      ended_at { 1.day.since(Time.zone.parse('09:50')) }
     end
 
     trait :from_9_30_to_10_30 do
-      started_at { 1.day.since(DateTime.parse('09:30')) }
-      ended_at { 1.day.since(DateTime.parse('10:30')) }
+      started_at { 1.day.since(Time.zone.parse('09:30')) }
+      ended_at { 1.day.since(Time.zone.parse('10:30')) }
     end
   end
 end

--- a/test/factories/reservations.rb
+++ b/test/factories/reservations.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :reservation do
+    comment { 'よろしくお願いします。楽しみです。' }
+    association :event
+    association :hosted_date
+    association :user
+  end
+end


### PR DESCRIPTION
## やったこと
- Reservationに関するモデルスペック、システムスペックを追加
- リファクタリング
  - イベント詳細ページに表示されている開催日が、ユーザーが予約済みの日だった場合、予約リンクがdisableになるよう修正 fixes #61 
    - ユーザーが予約済みかを確認する`reserved_by?(user)`メソッドを追加 
  - テストデータ作成の際、letメソッドを使うよう修正
  - テストデータ作成の際、FactoryBotクラス表記を省略
  - タイムゾーンを適用するためDateTimeでなく`Time.zone`を使用するよう変更
  - システムスペックでDeviseの`sign_in`を使えるように設定
  - LoginSupportモジュールを追加


## やっていないこと（今後実装予定）
- 特になし

## できるようになること（ユーザー目線）
- 予約済みの日付に対する予約するリンクがdisableになり、誤って予約することがなくなる

## できなくなること（ユーザ目線）
- 予約済みの日付に対する予約するリンクをクリックすることができなくなる

## 動作確認
- イベント詳細ページにて予約済み日付のリンクがクリックできなくなることを確認
- RSpec
```
$ rspec

EventsController
  #index
    as an authenticated user
      resoponds successfully
      returns a 200 response
    as a guest
      returns a 302 response
      redirects to the sign-in page
  #create
    as an authenticated user
      with valid attributes
        adds a event
      with invalid attributes
        does not add a event
    as a guest
      returns a 302 response
      redirect to the sign-in page
  #show
    as an authenticated user
      responds successfully
      returns a 200 response
    as a guest
      responds successfully
      returns a 200 response
  #update
    as an authorized user
      updates the event
    as an unauthorized user
      raises exeption error
    as a guest
      retunes a 302 response
      redirects to the sign-in page
  #destroy
    as an authorized user
      destroys the event
    as an unauthorized user
      raises exeption error
    as a guest
      retunes a 302 response
      redirects to the sign-in page

Event
  is valid with a name, place, title, discription, price, required_time, capacity and is_published
  is invalid without a name
  is invalid without a place
  is invalid without a title
  is invalid without a discription
  is invalid without a price
  is invalid without a required_time
  is invalid without a capacity
  is invalid without a is_published
  is invalid with a longer name than maximum length 50
  is invalid with a longer place than maximum length 100
  is invalid with a longer title than maximum length 100
  is invalid with a longer discription than maximum length 2000
  is invalid with a longer price than maximum length 7
  is invalid with a longer required_time than maximum length 3
  is invalid with a longer capacity than maximum length 3
  can have many hosted_dates
  owner
    is this user
    is not other user

HostedDate
  is valid when stated_at is after now
  is invalid when stated_at is before now
  is valid when started_at is before ended_at
  is invalid when ended_at is before started_at
  is valid when stared_at and ended_at are unique
  is invalid when both stared_at and ended_at are not unique
  overlapping validation for the default held from 9:00 to 10:00
    not overlapping
      is valid when held from 8:00 to 9:00
      is valid when held from 10:00 to 11:00
    overlapping
      is invalid when held from 8:30 to 9:30
      is invalid when held from 8:50 to 10:10
      is invalid when held from 9:10 to 9:50
      is invalid when held from 9:30 to 10:30

Reservation
  with comments
    is valid with a comment
    is valid with no comment
  with hosted_dates
    is valid with the different hosted_date
    is invalid with the same hosted_date
  with is_canceled
    is canceld when is_canceled is true
    is not canceld when is_canceled is false

User
  is valid with an email and password
  is invalid without an email
  is invalid without a password
  is invalid with a duplicate email address

Events
  user creates a new event

Reservations
  when user signs in
    user reserves the event
    after user reserves
      user can not click the link to the same hosted_date for reservation
      user can change to other hosted_date for the reservation
      user can cancel the reservation
    after other users reserve
      user can not click the link to no capacity
  when owner signs in
    owner can not click the link for own event reservation

Finished in 6.02 seconds (files took 1.07 seconds to load)
68 examples, 0 failures
```