### PR TITLE
CSS崩れ修正

### DIFF
--- a/app/views/dashboards/event_reservations.html.erb
+++ b/app/views/dashboards/event_reservations.html.erb
@@ -4,7 +4,7 @@
       <h1><%= @event.name %> </h1>
       <div class="btn-space">
         <% if @event.created_by?(current_user) %> 
-          <%= link_to '編集する', edit_event_path(@event), class: 'btn btn-default' %> 
+          <%= link_to '編集する', edit_event_path(@event), class: 'btn btn-outline-secondary' %> 
           <%= link_to '削除する', event_path(@event), class: 'btn btn-danger', method: :delete, data: { confirm: '本当に削除しますか？' } %> 
         <% end %> 
       </div>

--- a/app/views/events/_hosted_date.html.erb
+++ b/app/views/events/_hosted_date.html.erb
@@ -1,11 +1,11 @@
 <div class="row">
-  <div class="col-xs-6">
+  <div class="col">
     <%= f.label '開催日時' %>
   </div>
-  <div class="col-xs-6">
+  <div class="col">
     <div class="text-right">
       <%= link_to_add_association '開催日時を追加', f, :hosted_dates,
-        class: 'btn btn-default',
+        class: 'btn btn-outline-secondary',
         data: {
           association_insertion_node: '#detail-association-insertion-point',
           association_insertion_method: 'append' }
@@ -18,9 +18,9 @@
     <table class="table table-list">
       <thead>
         <tr>
-          <th>開始</th>
-          <th>終了</th>
-          <th></th>
+          <td>開始</td>
+          <td>終了</td>
+          <td></td>
         </tr>
       </thead>
       <tbody id='detail-association-insertion-point'>

--- a/app/views/events/_hosted_date_fields.html.erb
+++ b/app/views/events/_hosted_date_fields.html.erb
@@ -7,6 +7,6 @@
   <%= f.datetime_field :ended_at, min: @today.strftime('%Y-%m-%dT%T'), max: @today.next_year.strftime('%Y-%m-%dT%T'), step:600  %>
   </td>
   <td>
-  <%= link_to_remove_association '削除', f, class: 'btn btn-default' %>
+  <%= link_to_remove_association '削除', f, class: 'btn btn-outline-secondary' %>
   </td>
 </tr>

--- a/app/views/events/_hosted_date_show.html.erb
+++ b/app/views/events/_hosted_date_show.html.erb
@@ -9,7 +9,7 @@
       <span class="rest-capacity">残り<%= date.capacity_left %> 人</span>
     </td>
     <td>
-      <%= link_to '予約する', '#', class: "btn btn-default disabled" %>
+      <%= link_to '予約する', '#', class: "btn btn-outline-secondary disabled" %>
     </td>
   <% elsif date.available? %>
     <td>
@@ -17,7 +17,7 @@
       <span class="rest-capacity">残り<%= date.capacity_left %> 人</span>
     </td>
     <td>
-      <%= link_to '予約する', new_event_reservation_path(event_id: date.event, date_id: date), class: "btn btn-default" %>
+      <%= link_to '予約する', new_event_reservation_path(event_id: date.event, date_id: date), class: "btn btn-outline-secondary" %>
     </td>
   <% else %>
     <td>
@@ -25,7 +25,7 @@
       <span class="rest-capacity">残り0 人</span>
     </td>
     <td>
-      <%= link_to '予約する', '#', class: "btn btn-default disabled" %>
+      <%= link_to '予約する', '#', class: "btn btn-outline-secondary disabled" %>
     </td>
   <% end %>
 </tr>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,7 +4,7 @@
       <h1><%= @event.name %> </h1>
       <div class="btn-space">
         <% if @event.created_by?(current_user) %> 
-          <%= link_to '編集する', edit_event_path(@event), class: 'btn btn-default' %> 
+          <%= link_to '編集する', edit_event_path(@event), class: 'btn btn-outline-secondary' %> 
           <%= link_to '削除する', event_path(@event), class: 'btn btn-danger', method: :delete, data: { confirm: '本当に削除しますか？' } %> 
         <% end %> 
       </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,18 +1,31 @@
-<header class="navbar navbar-default">
-  <div class="container">
-    <%= link_to "wakuraku", root_path, class: "navbar-brand" %>
-    <ul class="nav navbar-nav navbar-right">
-      <% unless user_signed_in? %>
-        <li><%= link_to 'ログイン', new_user_session_path %></li>
-      <% else %>
-        <li><%= link_to 'ココロミをつくる', new_event_path %></li>
-        <li><%= link_to '予約したココロミ', user_reservations_path(current_user) %></li>
-        <li><%= link_to 'つくったココロミの予約一覧', dashboard_reservations_path %></li>
-        <li><%= link_to 'つくったココロミ一覧', dashboard_events_path %></li>
-        <li><%= link_to '顧客一覧', dashboard_customers_path %></li>
-        <li><%= link_to 'プロフィール', user_path(current_user) %></li>
-        <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete %></li>
-      <% end %>
+<header class="navbar navbar-expand-lg navbar-light bg-light">
+  <%= link_to "wakuraku", root_path, class: "navbar-brand" %>
+  <% unless user_signed_in? %>
+    <ul class="navbar-nav ml-auto">
+      <li class="nav-item"><%= link_to 'ログイン', new_user_session_path, class: 'nav-link' %></li>
     </ul>
-  </div>
+  <% else %>
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNavDropdown">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item"><%= link_to 'プロフィール', user_path(current_user), class: 'nav-link' %></li>
+        
+        <li class="nav-itme dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            ダッシュボード
+          </a>
+          <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+            <%= link_to 'ココロミをつくる', new_event_path, class: 'dropdown-item' %>
+            <%= link_to 'ココロミ一覧', dashboard_events_path, class: 'dropdown-item' %>
+            <%= link_to '予約一覧', dashboard_reservations_path, class: 'dropdown-item' %>
+            <%= link_to '顧客一覧', dashboard_customers_path, class: 'dropdown-item' %>
+          </div>
+        </li>
+        <li class="nav-item"><%= link_to '申し込み履歴', user_reservations_path(current_user), class: 'nav-link' %></li>
+        <li class="nav-item"><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link' %></li>
+      </ul>
+    </div>
+  <% end %>
 </header>

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -38,7 +38,7 @@
         </tr>
       </table>
       <div class="btn-area">
-        <%= f.submit '予約内容を変更する', class: 'btn btn-default btn-block' %> 
+        <%= f.submit '予約内容を変更する', class: 'btn btn-outline-secondary btn-block' %> 
         <div class="btn-modest">
           <%= link_to 'この予約をキャンセルする', user_reservation_path(user_id: current_user, reservaiton_id: @reservation), method: :delete, data: { confirm: '本当にキャンセルしますか？' } %> 
         </div>

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,6 +4,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system, js: true) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
   end
 end

--- a/spec/system/dashboards_spec.rb
+++ b/spec/system/dashboards_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe 'Dashboards', type: :system do
   end
 
   scenario 'owner gets #reservation_index and then #event_reservations' do
-    click_link 'つくったココロミの予約一覧'
-    expect(page).to have_content 'つくったココロミの予約一覧'
+    click_link 'ダッシュボード'
+    click_link '予約一覧'
+    expect(page).to have_content '予約一覧'
 
     within all('tr')[1] do
       expect(find('th')).to have_content 'バスソルト作り'
@@ -53,7 +54,8 @@ RSpec.describe 'Dashboards', type: :system do
   end
 
   scenario 'owner gets #event_index and then #event_reservations' do
-    click_link 'つくったココロミ一覧'
+    click_link 'ダッシュボード'
+    click_link 'ココロミ一覧'
     expect(page).to have_content 'ココロミ一覧'
 
     within all('tr')[1] do
@@ -80,6 +82,7 @@ RSpec.describe 'Dashboards', type: :system do
   end
 
   scenario 'owner gets #customer_index and then #customer_reservations' do
+    click_link 'ダッシュボード'
     click_link '顧客一覧'
     expect(page).to have_content '顧客一覧'
 

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Events', type: :system do
     click_button 'ログインする'
 
     expect {
+      click_link 'ダッシュボード'
       click_link 'ココロミをつくる'
       fill_in '名前', with: 'バスソルト作り'
       fill_in 'タイトル', with: '心身共にリラックスできるバスソルトを作りましょう'

--- a/spec/system/reservations_spec.rb
+++ b/spec/system/reservations_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Reservations', type: :system, js: true do
 
       scenario 'user can change to other hosted_date for the reservation' do
         visit root_path
-        click_link '予約したココロミ'
+        click_link '申し込み履歴'
         expect(page).to have_content 'バスソルト作り'
         expect(page).to have_content '08:00 - 09:00'
         click_link 'バスソルト作り'
@@ -76,7 +76,7 @@ RSpec.describe 'Reservations', type: :system, js: true do
 
       scenario 'user can cancel the reservation' do
         visit root_path
-        click_link '予約したココロミ'
+        click_link '申し込み履歴'
         expect(page).to have_content 'バスソルト作り'
         expect(page).to have_content '08:00 - 09:00'
         click_link 'バスソルト作り'


### PR DESCRIPTION
## やったこと
- Bootstrap4系へ移行したことによるcss崩れ修正
  - ナビゲーションデザインを修正
    - ブラウズサイズが狭い場合にログイン後のリンク集をハンバーガーメニューから選択できるように修正
    - オーナー用リンクをダッシュボード内へ統合
  - ボタンデザインの修正 
- ナビゲーションリンク変更に合わせたRSpec修正
## やっていないこと（今後実装予定）
- 特に無し

## できるようになること（ユーザー目線）
- ナビゲーションリンク配置変更により、アクセス性向上

## できなくなること（ユーザ目線）
- 特に無し

## 動作確認
ナビゲーションリンク（通常時）
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/87155363/210176344-f08c8695-0111-4b6a-9424-212e11f80a20.png">

ハンバーガーメニュー（ウィンドウサイズが狭い場合）
<img width="801" alt="image" src="https://user-images.githubusercontent.com/87155363/210176360-4750e834-bcbc-4870-b06c-43b94bdbd866.png">

イベント作成フォーム
<img width="793" alt="image" src="https://user-images.githubusercontent.com/87155363/210176383-25ae59f6-b377-4399-a2a6-309924c3e79b.png">

### RuboCop
指摘無し
### RSpec
全てパス