### PR TITLE
イベント検索機能を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ gem 'active_storage_validations'
 gem 'aws-sdk-s3'
 gem 'kaminari'
 gem 'faker'
+gem "searchkick"
+gem 'elasticsearch', "< 7.14"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,14 @@ GEM
     diff-lcs (1.5.0)
     discard (1.2.1)
       activerecord (>= 4.2, < 8)
+    elasticsearch (7.4.0)
+      elasticsearch-api (= 7.4.0)
+      elasticsearch-transport (= 7.4.0)
+    elasticsearch-api (7.4.0)
+      multi_json
+    elasticsearch-transport (7.4.0)
+      faraday
+      multi_json
     erubi (1.11.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -169,6 +177,7 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.6.0)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     net-imap (0.3.1)
       net-protocol
@@ -310,6 +319,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    searchkick (5.1.1)
+      activemodel (>= 5.2)
+      hashie
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -374,6 +386,7 @@ DEPENDENCIES
   cocoon
   devise
   discard (~> 1.2)
+  elasticsearch (< 7.14)
   factory_bot_rails
   faker
   font-awesome-sass (~> 6.2.0)
@@ -399,6 +412,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   sass-rails (>= 6)
+  searchkick
   selenium-webdriver (>= 4.0.0.rc1)
   spring
   turbolinks (~> 5)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,6 +9,6 @@ class HomeController < ApplicationController
   private
 
   def event_search_form_params
-    params.fetch(:event_search_form, {}).permit(:keyword).merge(page: params[:page])
+    params.fetch(:event_search_form, {}).permit(:keyword, :hosted_date).merge(page: params[:page])
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,13 @@ class HomeController < ApplicationController
   skip_before_action :authenticate_user!
 
   def index
-    @events = Event.with_recent_dates.page params[:page]
+    @event_search_form = EventSearchForm.new(event_search_form_params)
+    @events = @event_search_form.search
+  end
+
+  private
+
+  def event_search_form_params
+    params.fetch(:event_search_form, {}).permit(:keyword).merge(page: params[:page])
   end
 end

--- a/app/forms/event_search_form.rb
+++ b/app/forms/event_search_form.rb
@@ -1,0 +1,21 @@
+class EventSearchForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :keyword, :string
+  attribute :page, :integer
+
+  def search
+    Event.search(
+      keyword_for_search,
+      page: page,
+      per_page: 10
+    )
+  end
+
+  private
+
+  def keyword_for_search
+    keyword.presence || '*'
+  end
+end

--- a/app/forms/event_search_form.rb
+++ b/app/forms/event_search_form.rb
@@ -10,7 +10,8 @@ class EventSearchForm
     Event.search(
       keyword_for_search,
       includes: [:hosted_dates],
-      where: { hosted_dates: range_of_hosted_date },
+      where: { hosted_dates: range_of_hosted_date,
+               is_published: true },
       page: page,
       per_page: 10
     )

--- a/app/forms/event_search_form.rb
+++ b/app/forms/event_search_form.rb
@@ -4,18 +4,33 @@ class EventSearchForm
 
   attribute :keyword, :string
   attribute :page, :integer
+  attr_reader :hosted_date
 
   def search
     Event.search(
       keyword_for_search,
+      includes: [:hosted_dates],
+      where: { hosted_dates: range_of_hosted_date },
       page: page,
       per_page: 10
     )
+  end
+
+  def hosted_date=(new_hosted_date)
+    @hosted_date = new_hosted_date.in_time_zone
   end
 
   private
 
   def keyword_for_search
     keyword.presence || '*'
+  end
+
+  def range_of_hosted_date
+    if hosted_date.nil?
+      { gte: Time.current.midnight }
+    else
+      { gte: hosted_date, lt: hosted_date.tomorrow }
+    end
   end
 end

--- a/app/javascript/javascripts/get_form_turbolinks.js
+++ b/app/javascript/javascripts/get_form_turbolinks.js
@@ -4,7 +4,7 @@ document.addEventListener('turbolinks:load', function(event){
     form.addEventListener('ajax:beforeSend', function(event) {
       const options = event.detail[1]
 
-      Tubolinks.visit(options.url)
+      Turbolinks.visit(options.url)
       event.preventDefault()
     })
   }

--- a/app/javascript/javascripts/get_form_turbolinks.js
+++ b/app/javascript/javascripts/get_form_turbolinks.js
@@ -1,0 +1,11 @@
+document.addEventListener('turbolinks:load', function(event){
+  const forms = document.querySelectorAll('form[method=get][data-remote=true]')
+  for (const form of forms) {
+    form.addEventListener('ajax:beforeSend', function(event) {
+      const options = event.detail[1]
+
+      Tubolinks.visit(options.url)
+      event.preventDefault()
+    })
+  }
+})

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,6 +19,7 @@ const imagePath = (name) => images(name, true)
 // JavaScript
 import '../javascripts/image_upload_form.js'
 import '../javascripts/slick.js'
+import '../javascripts/get_form_turbolinks.js'
 
 // CSS
 import '../stylesheets/application.scss'

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  searchkick language: 'japanese'
+
   belongs_to :owner, class_name: 'User'
   has_many_attached :images, dependent: false
   has_many :hosted_dates, dependent: :destroy
@@ -34,6 +36,16 @@ class Event < ApplicationRecord
     return false unless user
 
     owner.id == user.id
+  end
+
+  def search_data
+    {
+      name: name,
+      place: place,
+      title: title,
+      discription: discription,
+      owner_name: owner&.name
+    }
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -45,8 +45,7 @@ class Event < ApplicationRecord
       title: title,
       discription: discription,
       is_published: is_published,
-      owner_name: owner&.name,
-      updated_at: updated_at,
+      owner_nickname: owner&.nickname,
       hosted_dates: hosted_dates.map(&:started_at)
     }
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -44,7 +44,10 @@ class Event < ApplicationRecord
       place: place,
       title: title,
       discription: discription,
-      owner_name: owner&.name
+      is_published: is_published,
+      owner_name: owner&.name,
+      updated_at: updated_at,
+      hosted_dates: hosted_dates.map(&:started_at)
     }
   end
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,8 +1,12 @@
 <h1>ココロミ一覧</h1>
-<%= form_with(model: @event_search_form, url: root_path, method: :get) do |f| %> 
+<%= form_with(model: @event_search_form, url: root_path, method: :get, local: false) do |f| %> 
   <div class="form-group">
     <%= f.label :keyword, 'キーワード' %> 
     <%= f.text_field :keyword, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= f.label :hosted_date, '開催日' %> 
+    <%= f.date_field :hosted_date, class: 'form-control' %> 
   </div>
   <div class="form-group">
     <%= f.submit '検索', class: 'btn btn-primary' %> 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,5 +1,13 @@
 <h1>ココロミ一覧</h1>
-
+<%= form_with(model: @event_search_form, url: root_path, method: :get) do |f| %> 
+  <div class="form-group">
+    <%= f.label :keyword, 'キーワード' %> 
+    <%= f.text_field :keyword, class: 'form-control' %> 
+  </div>
+  <div class="form-group">
+    <%= f.submit '検索', class: 'btn btn-primary' %> 
+  </div>
+<% end %> 
 <div class="list-group">
   <%= render partial: 'events/event_item', collection: @events, as: 'event' %>
 </div>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,17 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.before(:suite) do
+    Event.reindex
+    Searchkick.disable_callbacks
+  end
+
+  config.around(:each, search: true) do |example|
+    Searchkick.callbacks(nil) do
+      example.run
+    end
+  end
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin

--- a/spec/system/reservations_spec.rb
+++ b/spec/system/reservations_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe 'Reservations', type: :system, js: true do
     let!(:hosted_date_2) { create(:hosted_date, :from_10_to_11, event: event) }
     let(:user) { create(:user) }
 
+    before do
+      Event.reindex
+    end
+
     scenario 'user reserves the event' do
       sign_in user
       visit root_path
@@ -133,6 +137,7 @@ RSpec.describe 'Reservations', type: :system, js: true do
 
     before do
       create(:hosted_date, :from_10_to_11, event: event)
+      Event.reindex
 
       user.reservations.create(
         event: event,

--- a/spec/system/retirements_spec.rb
+++ b/spec/system/retirements_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'Retirements', type: :system, js: true do
   let(:user_2) { create(:user) }
 
   before do
+    Event.reindex
     user_1.reservations.create(
       event: event,
       hosted_date: hosted_date_1

--- a/test/factories/events.rb
+++ b/test/factories/events.rb
@@ -13,5 +13,11 @@ FactoryBot.define do
     trait :with_hosted_dates do
       after(:create) { |event| create_list(:hosted_date, 3, event: event) }
     end
+
+    trait :reindex do
+      after(:create) do |event, _evaluator|
+        event.reindex(refresh: true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## やったこと
- elasticsearchとearchkickにより検索機能を実装
  - デフォルト検索結果は本日以降に開催される公開イベントを表示(root_path)
  - キーワード検索は以下カラムに含まれるデータの完全一致に対応
    - イベント名
    - イベントタイトル
    - イベント詳細
    - オーナーのニックネーム
  - 日付検索は該当する開催日を持っているイベントを表示
  - ajaxでのGETリクエストによる投稿に対応して非同期で検索結果を表示
- 検索表示に対応するようspecファイルを修正

## やっていないこと（今後実装予定）
- 特になし

## できるようになること（ユーザー目線）
- 検索により目的のイベントを見つけやすくなる
- 検索結果のURLを共有できるようになる

## できなくなること（ユーザ目線）
- 特に無し

## 動作確認
トップページは本日以降に開催される公開イベントが表示されている
<img width="922" alt="image" src="https://user-images.githubusercontent.com/87155363/211253164-62efc8d5-b761-428f-847e-20319b1755fc.png">

キーワードと日付で結果が絞り込まれること
<img width="804" alt="image" src="https://user-images.githubusercontent.com/87155363/211253871-5144231a-ba6d-49c2-9361-a6ddca1cc571.png">

### RuboCop
指摘無し
### RSpec
全てパス